### PR TITLE
Expose the tbsCertificate byte representation

### DIFF
--- a/src/x509.rs
+++ b/src/x509.rs
@@ -96,6 +96,7 @@ pub struct TbsCertificate<'a> {
     pub issuer_uid: Option<UniqueIdentifier<'a>>,
     pub subject_uid: Option<UniqueIdentifier<'a>>,
     pub extensions: Vec<X509Extension<'a>>,
+    pub(crate) raw: &'a [u8],
 }
 
 #[derive(Debug, PartialEq)]
@@ -147,6 +148,12 @@ fn check_validity_expiration() {
 pub struct UniqueIdentifier<'a>(pub BitStringObject<'a>);
 
 impl<'a> TbsCertificate<'a> {
+    /// Return the ASN.1 DER encoding of the tbsCertificate.
+    /// This data is used for the signature.
+    pub fn bytes(&self) -> &[u8] {
+        &self.raw
+    } 
+
     /// Returns true if certificate has `basicConstraints CA:true`
     pub fn is_ca(&self) -> bool {
         // filter on ext: OId(basicConstraints)

--- a/tests/readcert.rs
+++ b/tests/readcert.rs
@@ -23,6 +23,8 @@ fn test_x509_parser() {
             let tbs_cert = cert.tbs_certificate;
             assert_eq!(tbs_cert.version, 2);
             //
+            assert_eq!(tbs_cert.bytes(), &IGCA_DER[4..754]);
+            //
             let expected_subject = "C=FR, ST=France, L=Paris, O=PM/SGDN, OU=DCSSI, CN=IGC/A, Email=igca@sgdn.pm.gouv.fr";
             assert_eq!(format!("{}", tbs_cert.subject), expected_subject);
             //


### PR DESCRIPTION
Closes #13

Edit: The test case was created using the Python package `cryptography`.