### PR TITLE
Expose tbs bytes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x509-parser"
-version = "0.6.0"
+version = "0.6.1"
 description = "Parser for the X.509 v3 format (RFC 5280 certificates)"
 license = "MIT/Apache-2.0"
 keywords = ["X509","Certificate","parser","nom"]
@@ -25,10 +25,10 @@ include = [
 [dependencies]
 base64 = "0.10"
 nom = "5.0"
-rusticata-macros = "2.0.2"
+rusticata-macros = "2.0"
 num-bigint = "0.2"
 time = "0.1"
-der-parser = {version = "3.0.0", features=["bigint"] }
+der-parser = {version = "3.0", features=["bigint"] }
 
 [badges]
 travis-ci = { repository = "rusticata/x509-parser" }

--- a/src/x509.rs
+++ b/src/x509.rs
@@ -212,7 +212,8 @@ fn x509name_to_string(rdn_seq: &[RelativeDistinguishedName]) -> Result<String,X5
 pub struct X509Certificate<'a> {
     pub tbs_certificate: TbsCertificate<'a>,
     pub signature_algorithm: AlgorithmIdentifier<'a>,
-    pub signature_value: BitStringObject<'a>
+    pub signature_value: BitStringObject<'a>,
+    pub tbs_bytes: &'a [u8],
 }
 
 


### PR DESCRIPTION
This PR exposes the raw bytes of the `tbsCertificate` so that they can be verified against the signature.