### PR TITLE
Expose tbsCertificate bytes

### DIFF
--- a/src/x509.rs
+++ b/src/x509.rs
@@ -96,6 +96,13 @@ pub struct TbsCertificate<'a> {
     pub issuer_uid: Option<UniqueIdentifier<'a>>,
     pub subject_uid: Option<UniqueIdentifier<'a>>,
     pub extensions: Vec<X509Extension<'a>>,
+    pub(crate) raw: &'a [u8]
+}
+
+impl<'a> AsRef<[u8]> for TbsCertificate<'a> {
+    fn as_ref(&self) -> &[u8] {
+        &self.raw
+    }
 }
 
 #[derive(Debug, PartialEq)]

--- a/src/x509_parser.rs
+++ b/src/x509_parser.rs
@@ -272,10 +272,14 @@ fn parse_tbs_certificate(i:&[u8]) -> IResult<&[u8],TbsCertificate,BerError> {
                 subject_pki,
                 issuer_uid,
                 subject_uid,
-                extensions
+                extensions,
+                raw: &[]
             }
         )
-    ).map(|(rem,x)| (rem,x.1))
+    ).map(|(rem, (_hdr, mut tbs))| {
+        tbs.raw = &i[..(i.len() - rem.len())];
+        (rem, tbs)
+    })
 }
 
 fn parse_algorithm_identifier(i:&[u8]) -> IResult<&[u8],AlgorithmIdentifier,BerError> {

--- a/tests/readcert.rs
+++ b/tests/readcert.rs
@@ -69,6 +69,8 @@ fn test_x509_parser() {
             assert_eq!(tbs_cert.extensions.iter().eq(expected_extensions.iter()), true);
             //
             assert_eq!(tbs_cert.is_ca(), true);
+            //
+            assert_eq!(tbs_cert.as_ref(), &IGCA_DER[4..(8 + 746)]);
         },
         _ => panic!("x509 parsing failed: {:?}", res),
     }


### PR DESCRIPTION
take 2

The test case offset was determined using the following script:
```python
from Crypto.Util.asn1 import DerSequence
der = open('IGC_A.der', 'rb').read()
cert = DerSequence().decode(der)
tbs = DerSequence().decode(cert[0])
print(len(tbs.payload))
```
with the knowledge that a BER header is 4 bytes.

The signature algo was verified using `ring::signature::ECDSA_P256_SHA256_ASN1`