### PR TITLE
Remove println from parser

### DIFF
--- a/src/pem.rs
+++ b/src/pem.rs
@@ -104,7 +104,6 @@ impl Pem {
         let mut line = String::new();
         let label = loop {
             r.read_line(&mut line).or(Err(PEMError::MissingHeader))?;
-            println!("line: {}", line);
             if !line.starts_with("-----BEGIN ") {
                 line.clear();
                 continue;


### PR DESCRIPTION
The latest x509_parser is broken for me since 0285fef (0.6.1).

This patch removes the `println!` from the parse function, please release a new update with this change.