### PR TITLE
Make extension parsing more robust

### DIFF
--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -153,7 +153,7 @@ pub(crate) mod parser {
     use der_parser::{oid::Oid, *};
     use nom::{alt, call, do_parse, eof, exact, many1, opt, take, verify, Err, IResult};
 
-    pub(crate) fn parse_extension<'a>(
+    fn parse_extension0<'a>(
         orig_i: &'a [u8],
         i: &'a [u8],
         oid: &Oid,
@@ -189,6 +189,18 @@ pub(crate) mod parser {
             ParsedExtension::UnsupportedExtension
         };
         Ok((orig_i, ext))
+    }
+
+    pub(crate) fn parse_extension<'a>(
+        orig_i: &'a [u8],
+        i: &'a [u8],
+        oid: &Oid,
+    ) -> IResult<&'a [u8], ParsedExtension<'a>, BerError> {
+        let r = parse_extension0(orig_i, i, oid);
+        if let Err(nom::Err::Incomplete(_)) = r {
+            return Ok((orig_i, ParsedExtension::UnsupportedExtension));
+        }
+        r
     }
 
     /// Parse a "Basic Constraints" extension


### PR DESCRIPTION
Fall back to UnsupportedExtension when an extension parser fails with
Incomplete.
This allows parsing the remaining extensions, instead of silently eating
the rest of the certificate with no indication that the parse was
partial.

Let's encrypt certificates triggered this issue.
I was unable to fix the basicConstraints parsing, but at least with this
I am able to access the whole set of extensions.