### PR TITLE
Expand the public API slightly

### DIFF
--- a/src/x509.rs
+++ b/src/x509.rs
@@ -48,7 +48,7 @@ impl<'a> X509Extension<'a> {
     }
 
     /// Return the extension type or `None` if the extension is not implemented.
-    pub fn parsed_extension(&self) -> &ParsedExtension {
+    pub fn parsed_extension(&self) -> &ParsedExtension<'a> {
         &self.parsed_extension
     }
 }

--- a/src/x509.rs
+++ b/src/x509.rs
@@ -79,6 +79,14 @@ pub struct AlgorithmIdentifier<'a> {
 #[derive(Debug, PartialEq)]
 pub struct X509Name<'a> {
     pub rdn_seq: Vec<RelativeDistinguishedName<'a>>,
+    pub(crate) raw: &'a [u8],
+}
+
+impl<'a> X509Name<'a> {
+    // Not using the AsRef trait, as that would not give back the full 'a lifetime
+    pub fn as_raw(&self) -> &'a [u8] {
+        self.raw
+    }
 }
 
 impl<'a> fmt::Display for X509Name<'a> {
@@ -502,6 +510,7 @@ mod tests {
                     ],
                 },
             ],
+            raw: &[], // incorrect, but enough for testing
         };
         assert_eq!(
             name.to_string(),

--- a/src/x509_parser.rs
+++ b/src/x509_parser.rs
@@ -51,7 +51,7 @@ fn parse_rdn(i: &[u8]) -> BerResult<RelativeDistinguishedName> {
     .map(|(rem, x)| (rem, x.1))
 }
 
-pub(crate) fn parse_name(i: &[u8]) -> BerResult<X509Name> {
+pub fn parse_name(i: &[u8]) -> BerResult<X509Name> {
     parse_der_struct!(
         i,
         TAG DerTag::Sequence,

--- a/src/x509_parser.rs
+++ b/src/x509_parser.rs
@@ -56,9 +56,18 @@ pub(crate) fn parse_name(i: &[u8]) -> BerResult<X509Name> {
         i,
         TAG DerTag::Sequence,
         v: many1!(complete!(parse_rdn)) >>
-        ( X509Name{ rdn_seq:v } )
+        ( v )
     )
-    .map(|(rem, x)| (rem, x.1))
+    .map(|(rem, x)| {
+        let len = i.len() - rem.len();
+        (
+            rem,
+            X509Name {
+                rdn_seq: x.1,
+                raw: &i[..len],
+            },
+        )
+    })
 }
 
 fn parse_version(i: &[u8]) -> BerResult<u32> {

--- a/tests/readcert.rs
+++ b/tests/readcert.rs
@@ -35,6 +35,8 @@ fn test_x509_parser() {
             //
             let expected_issuer = "C=FR, ST=France, L=Paris, O=PM/SGDN, OU=DCSSI, CN=IGC/A, Email=igca@sgdn.pm.gouv.fr";
             assert_eq!(format!("{}", tbs_cert.issuer), expected_issuer);
+            let expected_issuer_der = &IGCA_DER[35..171];
+            assert_eq!(tbs_cert.issuer.as_raw(), expected_issuer_der);
             //
             let sig_alg = &cert.signature_algorithm;
             assert_eq!(sig_alg.algorithm, OID_RSA_SHA1);


### PR DESCRIPTION
For X509Name, exposes parsing as well as accessing the raw data after parsing.

For parsed certificate extensions, this fixes an unnecessarily short lifetime.