### PR TITLE
Fix unnecessary use of pem_to_der in example

### DIFF
--- a/src/pem.rs
+++ b/src/pem.rs
@@ -7,12 +7,11 @@
 //!
 //! ```rust,no_run
 //! use std::io::Cursor;
-//! use x509_parser::pem::{pem_to_der, Pem};
+//! use x509_parser::pem::Pem;
 //!
 //! static IGCA_PEM: &'static [u8] = include_bytes!("../assets/IGC_A.pem");
 //!
 //! # fn main() {
-//! let res = pem_to_der(IGCA_PEM);
 //! let reader = Cursor::new(IGCA_PEM);
 //! let (pem,bytes_read) = Pem::read(reader).expect("Reading PEM failed");
 //! let x509 = pem.parse_x509().expect("X.509: decoding DER failed");


### PR DESCRIPTION
The `pem` module documentation was a bit confusing because it gave an
example using `pem_to_der`, then said "Another method to parse the
certificate is to use `pem_to_der`" and gave another example using
`pem_to_der`. Fixed by removing the unnecessary call to `pem_to_der`
in the first example.