### PR TITLE
Make parse_tbs_certificate public

### DIFF
--- a/src/x509_parser.rs
+++ b/src/x509_parser.rs
@@ -264,7 +264,7 @@ fn get_serial_info(o: DerObject) -> Option<(&[u8], BigUint)> {
     Some((slice, big))
 }
 
-fn parse_tbs_certificate<'a>(i: &'a [u8]) -> X509Result<TbsCertificate<'a>> {
+pub fn parse_tbs_certificate<'a>(i: &'a [u8]) -> X509Result<TbsCertificate<'a>> {
     let start_i = i;
     parse_ber_sequence_defined_g(move |i| {
         let (i, version) = parse_version(i)?;


### PR DESCRIPTION
### Motivation

TbsCertificate::as_ref can be used to get a byte representation of the TbsCertificate, and parse_tbs_certificate successfully parses those bytes. This PR exposes parse_tbs_certificate as a public method so it can be used in this manner.