### PR TITLE
Add support for parsing certification requests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,3 +50,6 @@ thiserror = "1.0"
 
 [badges]
 travis-ci = { repository = "rusticata/x509-parser" }
+
+[patch.crates-io]
+oid-registry = { git = "https://github.com/djc/oid-registry", branch = "extension-request" }

--- a/src/cri_attributes.rs
+++ b/src/cri_attributes.rs
@@ -1,0 +1,70 @@
+use crate::x509::X509Extension;
+use der_parser::oid::Oid;
+use oid_registry::*;
+use std::collections::HashMap;
+
+/// Section 3.1 of rfc 5272
+#[derive(Debug, PartialEq)]
+pub struct ExtensionRequest<'a> {
+    pub extensions: HashMap<Oid<'a>, X509Extension<'a>>,
+}
+
+/// Attributes for Certification Request
+#[derive(Debug, PartialEq)]
+pub enum ParsedCriAttribute<'a> {
+    ExtensionRequest(ExtensionRequest<'a>),
+    UnsupportedAttribute,
+}
+
+pub(crate) mod parser {
+    use crate::cri_attributes::*;
+    use der_parser::error::BerError;
+    use der_parser::{oid::Oid, *};
+    use lazy_static::lazy_static;
+    use nom::{Err, IResult};
+
+    type AttrParser = fn(&[u8]) -> IResult<&[u8], ParsedCriAttribute, BerError>;
+
+    lazy_static! {
+        static ref ATTRIBUTE_PARSERS: HashMap<Oid<'static>, AttrParser> = {
+            macro_rules! add {
+                ($m:ident, $oid:ident, $p:ident) => {
+                    $m.insert($oid, $p as AttrParser);
+                };
+            }
+
+            let mut m = HashMap::new();
+            add!(m, OID_PKCS9_EXTENSION_REQUEST, parse_extension_request);
+            m
+        };
+    }
+
+    // look into the parser map if the extension is known, and parse it
+    // otherwise, leave it as UnsupportedExtension
+    pub(crate) fn parse_attribute<'a>(
+        i: &'a [u8],
+        oid: &Oid,
+    ) -> IResult<&'a [u8], ParsedCriAttribute<'a>, BerError> {
+        if let Some(parser) = ATTRIBUTE_PARSERS.get(oid) {
+            parser(i)
+        } else {
+            Ok((i, ParsedCriAttribute::UnsupportedAttribute))
+        }
+    }
+
+    fn parse_extension_request<'a>(
+        i: &'a [u8],
+    ) -> IResult<&'a [u8], ParsedCriAttribute<'a>, BerError> {
+        crate::x509_parser::parse_extension_sequence(i)
+            .and_then(|(i, extensions)| {
+                crate::x509_parser::extensions_sequence_to_map(i, extensions)
+            })
+            .map(|(i, extensions)| {
+                (
+                    i,
+                    ParsedCriAttribute::ExtensionRequest(ExtensionRequest { extensions }),
+                )
+            })
+            .map_err(|_| Err::Error(BerError::BerTypeError))
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -37,8 +37,12 @@ pub enum X509Error {
     InvalidIssuerUID,
     #[error("invalid extensions")]
     InvalidExtensions,
+    #[error("invalid attributes")]
+    InvalidAttributes,
     #[error("duplicate extensions")]
     DuplicateExtensions,
+    #[error("duplicate attributes")]
+    DuplicateAttributes,
     #[error("invalid Signature DER Value")]
     InvalidSignatureValue,
     #[error("invalid TBS certificate")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,6 +126,7 @@
 pub use x509::*;
 pub mod x509;
 
+pub mod cri_attributes;
 pub mod error;
 pub mod extensions;
 pub mod objects;

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -2,7 +2,7 @@
 #[cfg_attr(docsrs, doc(cfg(feature = "verify")))]
 mod x509_verify {
     use crate::error::X509Error;
-    use crate::x509::{SubjectPublicKeyInfo, X509Certificate};
+    use crate::x509::{SubjectPublicKeyInfo, X509Certificate, X509CertificationRequest};
     use oid_registry::*;
     use ring::signature;
 
@@ -44,6 +44,48 @@ mod x509_verify {
             // verify signature
             let sig = self.signature_value.data;
             key.verify(self.tbs_certificate.raw, sig)
+                .or(Err(X509Error::SignatureVerificationError))
+        }
+    }
+
+    impl<'a> X509CertificationRequest<'a> {
+        /// Verify the cryptographic signature of this certificate
+        ///
+        /// `public_key` is the public key of the **signer**. For a self-signed certificate,
+        /// (for ex. a public root certificate authority), this is the key from the certificate,
+        /// so you can use `None`.
+        ///
+        /// For a leaf certificate, this is the public key of the certificate that signed it.
+        /// It is usually an intermediate authority.
+        pub fn verify_signature(
+            &self,
+            public_key: Option<&SubjectPublicKeyInfo>,
+        ) -> Result<(), X509Error> {
+            let spki = public_key.unwrap_or(&self.certification_request_info.subject_pki);
+            let signature_alg = &self.signature_algorithm.algorithm;
+            // identify verification algorithm
+            let verification_alg: &dyn signature::VerificationAlgorithm =
+                if *signature_alg == OID_PKCS1_SHA1WITHRSA {
+                    &signature::RSA_PKCS1_1024_8192_SHA1_FOR_LEGACY_USE_ONLY
+                } else if *signature_alg == OID_PKCS1_SHA256WITHRSA {
+                    &signature::RSA_PKCS1_2048_8192_SHA256
+                } else if *signature_alg == OID_PKCS1_SHA384WITHRSA {
+                    &signature::RSA_PKCS1_2048_8192_SHA384
+                } else if *signature_alg == OID_PKCS1_SHA512WITHRSA {
+                    &signature::RSA_PKCS1_2048_8192_SHA512
+                } else if *signature_alg == OID_SIG_ECDSA_WITH_SHA256 {
+                    &signature::ECDSA_P256_SHA256_ASN1
+                } else if *signature_alg == OID_SIG_ECDSA_WITH_SHA384 {
+                    &signature::ECDSA_P384_SHA384_ASN1
+                } else {
+                    return Err(X509Error::SignatureUnsupportedAlgorithm);
+                };
+            // get public key
+            let key =
+                signature::UnparsedPublicKey::new(verification_alg, spki.subject_public_key.data);
+            // verify signature
+            let sig = self.signature_value.data;
+            key.verify(self.certification_request_info.raw, sig)
                 .or(Err(X509Error::SignatureVerificationError))
         }
     }


### PR DESCRIPTION
I'd like to add CSR parsing code to this crate. I'm happy to incorporate any feedback you have.

Depends on https://github.com/rusticata/oid-registry/pull/1 (via a Git dependency for now).