### PR TITLE
Fix certificate validity period check

### DIFF
--- a/src/certificate.rs
+++ b/src/certificate.rs
@@ -410,7 +410,7 @@ impl Validity {
     /// Check the certificate time validity for the provided date/time
     #[inline]
     pub fn is_valid_at(&self, time: ASN1Time) -> bool {
-        time >= self.not_before && time < self.not_after
+        time >= self.not_before && time <= self.not_after
     }
 
     /// Check the certificate time validity


### PR DESCRIPTION
According to RFC #5280 4.1.2.5, "the validity period for a certificate is the period of time from notBefore through notAfter, inclusive." At present, `is_valid_at` treats `notAfter` as exclusive. This commit fixes the issue by treating `notAfter` as inclusive.