### PR TITLE
Expose TbsCertificate::raw, TbsCertificate::raw_serial

### DIFF
--- a/src/certificate.rs
+++ b/src/certificate.rs
@@ -217,8 +217,10 @@ pub struct TbsCertificate<'a> {
     pub issuer_uid: Option<UniqueIdentifier<'a>>,
     pub subject_uid: Option<UniqueIdentifier<'a>>,
     pub extensions: HashMap<Oid<'a>, X509Extension<'a>>,
-    pub(crate) raw: &'a [u8],
-    pub(crate) raw_serial: &'a [u8],
+    /// The raw bytes from which this certificate was parsed.
+    pub raw: &'a [u8],
+    /// The raw bytes for `serial`.
+    pub raw_serial: &'a [u8],
 }
 
 impl<'a> TbsCertificate<'a> {


### PR DESCRIPTION
`TbsCertificate::raw` is required to verify signatures externally. The bytes passed to the parse function (thus available to the consumer of this API) may not coincide with `TbsCertificate::raw` when parsing consumes only _some_ of the bytes. As such, exposing this field is necessary.

I've also exposed `TbsCertificate::raw_serial`, for parity.