### PR TITLE
Added ReasonFlags struct for CRLDistributionPoints extension

### DIFF
--- a/examples/print-cert.rs
+++ b/examples/print-cert.rs
@@ -56,7 +56,7 @@ fn print_x509_extension(oid: &Oid, ext: &X509Extension) {
                     println!("        Full Name: {:?}", name);
                 }
                 if let Some(reasons) = &point.reasons {
-                    println!("        Reasons: {:?}", reasons);
+                    println!("        Reasons: {}", reasons);
                 }
                 if let Some(crl_issuer) = &point.crl_issuer {
                     print!("        CRL Issuer: ");


### PR DESCRIPTION
Before CRLDistributionPoints gets released, added ReasonFlags which works similar to other flag structures like NSCertType.

Note, the tests are still commented due to an issue with openssl certificates #97 