### PR TITLE
Fix new clippy errors

### DIFF
--- a/src/certificate.rs
+++ b/src/certificate.rs
@@ -377,7 +377,7 @@ impl<'a> TbsCertificate<'a> {
 
 impl<'a> AsRef<[u8]> for TbsCertificate<'a> {
     fn as_ref(&self) -> &[u8] {
-        &self.raw
+        self.raw
     }
 }
 

--- a/src/extensions.rs
+++ b/src/extensions.rs
@@ -421,7 +421,7 @@ impl<'a> AuthorityInfoAccess<'a> {
                 access_method: oid,
                 access_location: gn,
             } = desc;
-            if let Some(general_names) = m.get_mut(&oid) {
+            if let Some(general_names) = m.get_mut(oid) {
                 general_names.push(gn);
             } else {
                 m.insert(oid.clone(), vec![gn]);
@@ -507,7 +507,7 @@ impl<'a> PolicyMappings<'a> {
                 issuer_domain_policy: left,
                 subject_domain_policy: right,
             } = desc;
-            if let Some(l) = m.get_mut(&left) {
+            if let Some(l) = m.get_mut(left) {
                 l.push(right);
             } else {
                 m.insert(left.clone(), vec![right]);

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -54,15 +54,12 @@ pub fn oid2abbrev<'a>(oid: &'a Oid, registry: &'a OidRegistry) -> Result<&'a str
 
 /// Returns the short name corresponding to the OID
 pub fn oid2sn<'a>(oid: &'a Oid, registry: &'a OidRegistry) -> Result<&'a str, NidError> {
-    registry.get(oid).map(|ref o| o.sn()).ok_or(NidError)
+    registry.get(oid).map(|o| o.sn()).ok_or(NidError)
 }
 
 /// Returns the description corresponding to the OID
 pub fn oid2description<'a>(oid: &'a Oid, registry: &'a OidRegistry) -> Result<&'a str, NidError> {
-    registry
-        .get(oid)
-        .map(|ref o| o.description())
-        .ok_or(NidError)
+    registry.get(oid).map(|o| o.description()).ok_or(NidError)
 }
 
 /// Return a reference to the default registry of known OIDs

--- a/src/revocation_list.rs
+++ b/src/revocation_list.rs
@@ -199,7 +199,7 @@ impl<'a> TbsCertList<'a> {
 
 impl<'a> AsRef<[u8]> for TbsCertList<'a> {
     fn as_ref(&self) -> &[u8] {
-        &self.raw
+        self.raw
     }
 }
 


### PR DESCRIPTION
Looks like new release of rust brought in new clippy warnings around references.