### PR TITLE
Fix rustdoc.

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -5,7 +5,12 @@ use crate::error::X509Result;
 ///
 /// The returned object uses zero-copy, and so has the same lifetime as the input.
 ///
-/// Note that only parsing is done, not validation (see the [`Validate`](crate::validate::Validate) trait).
+#[cfg_attr(feature = "validate", doc = r#"
+Note that only parsing is done, not validation (see the [`Validate`](crate::validate::Validate) trait).
+"#)]
+#[cfg_attr(not(feature = "validate"), doc = r#"
+Note that only parsing is done, not validation.
+"#)]
 ///
 /// # Example
 ///


### PR DESCRIPTION
The rustdoc build links to the Validate trait, but that is only available when the validate feature is set.  If rustdoc is run without that feature, it will error due to deny(broken_intra_doc_links).  This changes the comment so that it only links to that trait if the feature is set.