### PR TITLE
Tighten dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,9 +45,9 @@ lazy_static = "1.4"
 nom = "7.0"
 oid-registry = { version="0.2.0", features=["crypto", "x509"] }
 rusticata-macros = "4.0"
-ring = { version="0.16", optional=true }
+ring = { version="0.16.11", optional=true }
 der-parser = { version = "6.0.0", features=["bigint"] }
-thiserror = "1.0"
+thiserror = "1.0.2"
 
 [patch.crates-io]
 oid-registry = { git="https://github.com/rusticata/oid-registry" }


### PR DESCRIPTION
Ensure things build when resolving dependencies to minimal versions.

Checked with:

    cargo +nightly update -Z minimal-versions; cargo check

There's probably a way to do this in CI, but I haven't looked into it.