### PR TITLE
Fix regression with certificate verification

### DIFF
--- a/src/certificate.rs
+++ b/src/certificate.rs
@@ -131,6 +131,7 @@ impl<'a> X509Certificate<'a> {
         if curve_oid == &OID_EC_P256 {
             match sha_len {
                 256 => Some(&signature::ECDSA_P256_SHA256_ASN1),
+                384 => Some(&signature::ECDSA_P256_SHA384_ASN1),
                 _ => None,
             }
         } else if curve_oid == &OID_NIST_EC_P384 {


### PR DESCRIPTION
Handle verification of ASN.1 DER-encoded ECDSA signatures using the P-256 curve and SHA-384.

Even though this specific combination is not recommended by `ring`, the `verify_signature` method already supports other not recommended combinations.

Moreover, this used to work until the release 0.12.0, but stopped with the 0.13.0 one.