### PR TITLE
Depend on correct version of 'time'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,4 +50,4 @@ rusticata-macros = "4.0"
 ring = { version="0.16.11", optional=true }
 der-parser = { version = "7.0.0", features=["bigint"] }
 thiserror = "1.0.2"
-time = { version="0.3", features=["formatting"] }
+time = { version="0.3.7", features=["formatting"] }


### PR DESCRIPTION
The RFC2822 "well-known" format was added in time v0.3.7. As a result, this crate must depend on at least that version.

...or risk builds that fail because an older version of `time` is pulled in that doesn't yet contain the format.