### PR TITLE
Switch base64 decoding to `data-encoding` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,6 @@ validate = []
 
 [dependencies]
 asn1-rs = { version = "0.5", features=["datetime"] }
-base64 = "0.21"
 data-encoding = "2.2.1"
 lazy_static = "1.4"
 nom = "7.0"

--- a/src/pem.rs
+++ b/src/pem.rs
@@ -60,7 +60,6 @@
 use crate::certificate::X509Certificate;
 use crate::error::{PEMError, X509Error};
 use crate::parse_x509_certificate;
-use base64::Engine as _;
 use nom::{Err, IResult};
 use std::io::{BufRead, Cursor, Seek};
 
@@ -148,8 +147,8 @@ impl Pem {
             s.push_str(l.trim_end());
         }
 
-        let contents = base64::engine::general_purpose::STANDARD
-            .decode(&s)
+        let contents = data_encoding::BASE64
+            .decode(s.as_bytes())
             .or(Err(PEMError::Base64DecodeError))?;
         let pem = Pem {
             label: label.to_string(),


### PR DESCRIPTION
It was already previously used elsewhere in this crate and depending on two base64 implementations doesn't seem ideal.

----

Also fixes https://github.com/rusticata/x509-parser/pull/134