### PR TITLE
docs: fix broken FromDer trait link in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ DER.  A PEM-encoded certificate is a container, storing a DER object. See the
 [`pem`](https://docs.rs/x509-parser/latest/x509_parser/pem/index.html) module for more documentation.
 
 To decode a DER-encoded certificate, the main parsing method is
-[`X509Certificate::from_der`] (
-part of the [`FromDer`](https://docs.rs/x509-parser/latest/x509_parser/traits/trait.FromDer.html) trait
+`X509Certificate::from_der` (
+part of the [`FromDer`](https://docs.rs/x509-parser/latest/x509_parser/prelude/trait.FromDer.html) trait
 ), which builds a
 [`X509Certificate`](https://docs.rs/x509-parser/latest/x509_parser/certificate/struct.X509Certificate.html) object.
 


### PR DESCRIPTION
In ac46206 the `traits` module and `traits::FromDer` trait were replaced with a `pub use asn1_rs::FromDer;` directive in the `prelude` module, leaving a broken Rustdoc link in the project `README`.

This commit updates the link target to point to the `prelude` module's trait instead of the now-removed `traits` module's trait. Along the way I also removed some superfluous seeming square brackets around `X509Certificate::from_der` that were being rendered as part of the text.