### PR TITLE
x509: replace `fold` on `Try` types with `try_fold`.

### DIFF
--- a/src/x509.rs
+++ b/src/x509.rs
@@ -548,30 +548,26 @@ fn x509name_to_string(
     rdn_seq: &[RelativeDistinguishedName],
     oid_registry: &OidRegistry,
 ) -> Result<String, X509Error> {
-    rdn_seq.iter().fold(Ok(String::new()), |acc, rdn| {
-        acc.and_then(|mut _vec| {
-            rdn.set
-                .iter()
-                .fold(Ok(String::new()), |acc2, attr| {
-                    acc2.and_then(|mut _vec2| {
-                        let val_str = attribute_value_to_string(&attr.attr_value, &attr.attr_type)?;
-                        // look ABBREV, and if not found, use shortname
-                        let abbrev = match oid2abbrev(&attr.attr_type, oid_registry) {
-                            Ok(s) => String::from(s),
-                            _ => format!("{:?}", attr.attr_type),
-                        };
-                        let rdn = format!("{}={}", abbrev, val_str);
-                        match _vec2.len() {
-                            0 => Ok(rdn),
-                            _ => Ok(_vec2 + " + " + &rdn),
-                        }
-                    })
-                })
-                .map(|v| match _vec.len() {
-                    0 => v,
-                    _ => _vec + ", " + &v,
-                })
-        })
+    rdn_seq.iter().try_fold(String::new(), |acc, rdn| {
+        rdn.set
+            .iter()
+            .try_fold(String::new(), |acc2, attr| {
+                let val_str = attribute_value_to_string(&attr.attr_value, &attr.attr_type)?;
+                // look ABBREV, and if not found, use shortname
+                let abbrev = match oid2abbrev(&attr.attr_type, oid_registry) {
+                    Ok(s) => String::from(s),
+                    _ => format!("{:?}", attr.attr_type),
+                };
+                let rdn = format!("{}={}", abbrev, val_str);
+                match acc2.len() {
+                    0 => Ok(rdn),
+                    _ => Ok(acc2 + " + " + &rdn),
+                }
+            })
+            .map(|v| match acc.len() {
+                0 => v,
+                _ => acc + ", " + &v,
+            })
     })
 }
 


### PR DESCRIPTION
Latest clippy is flagging two instances of using `fold` on a type implementing `Try`, recommending the usage of `try_fold` instead.

This commit fixes both occurrences to resolve the clippy errors. See https://rust-lang.github.io/rust-clippy/master/index.html#/manual_try_fold for more detail.