### PR TITLE
Cargo.toml: pumped ring version to 0.17.5

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.57.0
+          - 1.61.0
           - nightly
     steps:
       - uses: actions/checkout@v2
@@ -22,8 +22,8 @@ jobs:
       - name: Cargo update
         run: cargo update
       - name: Cargo update (fix for MSRV)
-        run: cargo update -p time --precise 0.3.9
-        if: matrix.rust == '1.57.0'
+        run: cargo update -p time --precise 0.3.17
+        if: matrix.rust == '1.61.0'
       - uses: actions-rs/cargo@v1
         with:
           command: check
@@ -35,7 +35,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.57.0
+          - 1.61.0
           - nightly
     steps:
       - uses: actions/checkout@v2
@@ -47,8 +47,8 @@ jobs:
       - name: Cargo update
         run: cargo update
       - name: Cargo update (fix for MSRV)
-        run: cargo update -p time --precise 0.3.9
-        if: matrix.rust == '1.57.0'
+        run: cargo update -p time --precise 0.3.17
+        if: matrix.rust == '1.61.0'
       - uses: actions-rs/cargo@v1
         with:
           command: check

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.61.0
+          - 1.63.0
           - nightly
     steps:
       - uses: actions/checkout@v2
@@ -22,8 +22,8 @@ jobs:
       - name: Cargo update
         run: cargo update
       - name: Cargo update (fix for MSRV)
-        run: cargo update -p time --precise 0.3.17
-        if: matrix.rust == '1.61.0'
+        run: cargo update -p time --precise 0.3.34
+        if: matrix.rust == '1.63.0'
       - uses: actions-rs/cargo@v1
         with:
           command: check
@@ -35,7 +35,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.61.0
+          - 1.63.0
           - nightly
     steps:
       - uses: actions/checkout@v2
@@ -47,8 +47,8 @@ jobs:
       - name: Cargo update
         run: cargo update
       - name: Cargo update (fix for MSRV)
-        run: cargo update -p time --precise 0.3.17
-        if: matrix.rust == '1.61.0'
+        run: cargo update -p time --precise 0.3.34
+        if: matrix.rust == '1.63.0'
       - uses: actions-rs/cargo@v1
         with:
           command: check

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Cargo update
         run: cargo update
       - name: Cargo update (fix for MSRV)
-        run: cargo update -p time --precise 0.3.34
+        run: cargo update -p time --precise 0.3.20
         if: matrix.rust == '1.63.0'
       - uses: actions-rs/cargo@v1
         with:
@@ -47,7 +47,7 @@ jobs:
       - name: Cargo update
         run: cargo update
       - name: Cargo update (fix for MSRV)
-        run: cargo update -p time --precise 0.3.34
+        run: cargo update -p time --precise 0.3.20
         if: matrix.rust == '1.63.0'
       - uses: actions-rs/cargo@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ lazy_static = "1.4"
 nom = "7.0"
 oid-registry = { version="0.6", features=["crypto", "x509", "x962"] }
 rusticata-macros = "4.0"
-ring = { version="0.16.11", optional=true }
+ring = { version="0.17.5", optional=true }
 der-parser = { version = "8.1.0", features=["bigint"] }
 thiserror = "1.0.2"
 time = { version="0.3.7", features=["formatting"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,4 +49,4 @@ rusticata-macros = "4.0"
 ring = { version="0.17.5", optional=true }
 der-parser = { version = "8.1.0", features=["bigint"] }
 thiserror = "1.0.2"
-time = { version="0.3.7", features=["formatting"] }
+time = { version="0.3.17", features=["formatting"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/rusticata/x509-parser.git"
 categories = ["parser-implementations", "cryptography"]
 readme = "README.md"
 edition = "2018"
+rust-version = "1.63.0"
 
 include = [
   "CHANGELOG.md",
@@ -46,7 +47,7 @@ lazy_static = "1.4"
 nom = "7.0"
 oid-registry = { version="0.6", features=["crypto", "x509", "x962"] }
 rusticata-macros = "4.0"
-ring = { version="0.17.5", optional=true }
+ring = { version="0.17.7", optional=true }
 der-parser = { version = "8.1.0", features=["bigint"] }
 thiserror = "1.0.2"
-time = { version="0.3.17", features=["formatting"] }
+time = { version="0.3.34", features=["formatting"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,4 +50,4 @@ rusticata-macros = "4.0"
 ring = { version="0.17.7", optional=true }
 der-parser = { version = "8.1.0", features=["bigint"] }
 thiserror = "1.0.2"
-time = { version="0.3.34", features=["formatting"] }
+time = { version="0.3.20", features=["formatting"] }

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![crates.io](https://img.shields.io/crates/v/x509-parser.svg)](https://crates.io/crates/x509-parser)
 [![Download numbers](https://img.shields.io/crates/d/x509-parser.svg)](https://crates.io/crates/x509-parser)
 [![Github CI](https://github.com/rusticata/x509-parser/workflows/Continuous%20integration/badge.svg)](https://github.com/rusticata/x509-parser/actions)
-[![Minimum rustc version](https://img.shields.io/badge/rustc-1.57.0+-lightgray.svg)](#rust-version-requirements)
+[![Minimum rustc version](https://img.shields.io/badge/rustc-1.61.0+-lightgray.svg)](#rust-version-requirements)
 
 # X.509 Parser
 
@@ -103,12 +103,12 @@ pub fn check_signature(cert: &X509Certificate<'_>, issuer: &X509Certificate<'_>)
 
 ## Rust version requirements
 
-`x509-parser` requires **Rustc version 1.57 or greater**, based on der-parser
+`x509-parser` requires **Rustc version 1.61 or greater**, based on der-parser
 dependencies and for proc-macro attributes support.
 
 Note that due to breaking changes in the `time` crate, a specific version of this
-crate must be specified for compiler versions <= 1.57:
-`cargo update -p time --precise 0.3.9`
+crate must be specified for compiler versions <= 1.61:
+`cargo update -p time --precise 0.3.17`
 
 [RFC5280]: https://tools.ietf.org/html/rfc5280
 <!-- cargo-sync-readme end -->

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![crates.io](https://img.shields.io/crates/v/x509-parser.svg)](https://crates.io/crates/x509-parser)
 [![Download numbers](https://img.shields.io/crates/d/x509-parser.svg)](https://crates.io/crates/x509-parser)
 [![Github CI](https://github.com/rusticata/x509-parser/workflows/Continuous%20integration/badge.svg)](https://github.com/rusticata/x509-parser/actions)
-[![Minimum rustc version](https://img.shields.io/badge/rustc-1.61.0+-lightgray.svg)](#rust-version-requirements)
+[![Minimum rustc version](https://img.shields.io/badge/rustc-1.63.0+-lightgray.svg)](#rust-version-requirements)
 
 # X.509 Parser
 
@@ -103,12 +103,12 @@ pub fn check_signature(cert: &X509Certificate<'_>, issuer: &X509Certificate<'_>)
 
 ## Rust version requirements
 
-`x509-parser` requires **Rustc version 1.61 or greater**, based on der-parser
+`x509-parser` requires **Rustc version 1.63 or greater**, based on der-parser
 dependencies and for proc-macro attributes support.
 
 Note that due to breaking changes in the `time` crate, a specific version of this
-crate must be specified for compiler versions <= 1.61:
-`cargo update -p time --precise 0.3.17`
+crate must be specified for compiler versions <= 1.63:
+`cargo update -p time --precise 0.3.34`
 
 [RFC5280]: https://tools.ietf.org/html/rfc5280
 <!-- cargo-sync-readme end -->

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ dependencies and for proc-macro attributes support.
 
 Note that due to breaking changes in the `time` crate, a specific version of this
 crate must be specified for compiler versions <= 1.63:
-`cargo update -p time --precise 0.3.34`
+`cargo update -p time --precise 0.3.20`
 
 [RFC5280]: https://tools.ietf.org/html/rfc5280
 <!-- cargo-sync-readme end -->

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //! [![crates.io](https://img.shields.io/crates/v/x509-parser.svg)](https://crates.io/crates/x509-parser)
 //! [![Download numbers](https://img.shields.io/crates/d/x509-parser.svg)](https://crates.io/crates/x509-parser)
 //! [![Github CI](https://github.com/rusticata/x509-parser/workflows/Continuous%20integration/badge.svg)](https://github.com/rusticata/x509-parser/actions)
-//! [![Minimum rustc version](https://img.shields.io/badge/rustc-1.57.0+-lightgray.svg)](#rust-version-requirements)
+//! [![Minimum rustc version](https://img.shields.io/badge/rustc-1.61.0+-lightgray.svg)](#rust-version-requirements)
 //!
 //! # X.509 Parser
 //!
@@ -109,12 +109,12 @@
 //!
 //! ## Rust version requirements
 //!
-//! `x509-parser` requires **Rustc version 1.57 or greater**, based on der-parser
+//! `x509-parser` requires **Rustc version 1.61 or greater**, based on der-parser
 //! dependencies and for proc-macro attributes support.
 //!
 //! Note that due to breaking changes in the `time` crate, a specific version of this
-//! crate must be specified for compiler versions <= 1.57:
-//! `cargo update -p time --precise 0.3.9`
+//! crate must be specified for compiler versions <= 1.61:
+//! `cargo update -p time --precise 0.3.17`
 //!
 //! [RFC5280]: https://tools.ietf.org/html/rfc5280
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,7 @@
 //!
 //! Note that due to breaking changes in the `time` crate, a specific version of this
 //! crate must be specified for compiler versions <= 1.63:
-//! `cargo update -p time --precise 0.3.34`
+//! `cargo update -p time --precise 0.3.20`
 //!
 //! [RFC5280]: https://tools.ietf.org/html/rfc5280
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //! [![crates.io](https://img.shields.io/crates/v/x509-parser.svg)](https://crates.io/crates/x509-parser)
 //! [![Download numbers](https://img.shields.io/crates/d/x509-parser.svg)](https://crates.io/crates/x509-parser)
 //! [![Github CI](https://github.com/rusticata/x509-parser/workflows/Continuous%20integration/badge.svg)](https://github.com/rusticata/x509-parser/actions)
-//! [![Minimum rustc version](https://img.shields.io/badge/rustc-1.61.0+-lightgray.svg)](#rust-version-requirements)
+//! [![Minimum rustc version](https://img.shields.io/badge/rustc-1.63.0+-lightgray.svg)](#rust-version-requirements)
 //!
 //! # X.509 Parser
 //!
@@ -109,12 +109,12 @@
 //!
 //! ## Rust version requirements
 //!
-//! `x509-parser` requires **Rustc version 1.61 or greater**, based on der-parser
+//! `x509-parser` requires **Rustc version 1.63 or greater**, based on der-parser
 //! dependencies and for proc-macro attributes support.
 //!
 //! Note that due to breaking changes in the `time` crate, a specific version of this
-//! crate must be specified for compiler versions <= 1.61:
-//! `cargo update -p time --precise 0.3.17`
+//! crate must be specified for compiler versions <= 1.63:
+//! `cargo update -p time --precise 0.3.34`
 //!
 //! [RFC5280]: https://tools.ietf.org/html/rfc5280
 


### PR DESCRIPTION
Clippy checks pass using [pull/147](https://github.com/rusticata/x509-parser/pull/147).
Min supported rust version needs to be pumped to `1.61.0`.
If its acceptable, I can edit the workflow files to the new min supported rust version.