### PR TITLE
update ring dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ lazy_static = "1.4"
 nom = "7.0"
 oid-registry = { version="0.6", features=["crypto", "x509", "x962"] }
 rusticata-macros = "4.0"
-ring = { version="0.16.11", optional=true }
+ring = { version="0.17.5", optional=true }
 der-parser = { version = "8.1.0", features=["bigint"] }
 thiserror = "1.0.2"
 time = { version="0.3.7", features=["formatting"] }


### PR DESCRIPTION
Updating the [ring](https://github.com/briansmith/ring) dependency to 0.17.x to support compiling against more targets (e.g. riscv) when users are using the `verify` feature.

The new ring 0.17.x release has been slowly filtering through, here are some links to show the uptake:
* [rcgen](https://github.com/rustls/rcgen) - though the crate still has a dependency to x509-parser which is still on ring 0.16.20
* [rustls](https://github.com/rustls/rustls/issues/1522)

Note:
I opted to keep with the `x.x.x` version style in the Cargo.toml as I thought I would keep the convention, though I'd be happy to change it to `x.x` instead if that is preferred.