### PR TITLE
certificate: fix lifetime signature for subject_alt_names getter

### DIFF
--- a/src/certificate.rs
+++ b/src/certificate.rs
@@ -461,7 +461,7 @@ impl<'a> TbsCertificate<'a> {
     /// or an error if the extension is invalid, or is present twice or more.
     pub fn subject_alternative_name(
         &self,
-    ) -> Result<Option<BasicExtension<&SubjectAlternativeName>>, X509Error> {
+    ) -> Result<Option<BasicExtension<&SubjectAlternativeName<'a>>>, X509Error> {
         self.get_extension_unique(&OID_X509_EXT_SUBJECT_ALT_NAME)?
             .map_or(Ok(None), |ext| match ext.parsed_extension {
                 ParsedExtension::SubjectAlternativeName(ref value) => {


### PR DESCRIPTION
Let us consider the following code:

```rust
use x509_parser::certificate::X509Certificate;
use x509_parser::extensions::GeneralName;
use x509_parser::prelude::FromDer;

fn foo(data: &[u8]) -> Vec<GeneralName> {
    X509Certificate::from_der(data)
        .unwrap()
        .1
        .subject_alternative_name()
        .unwrap()
        .unwrap()
        .value
        .general_names
        .clone()
}
```

---

#### Before the patch (does not compile)
```
error[E0515]: cannot return value referencing temporary value
  --> examples/my.rs:6:5
   |
6  | //     X509Certificate::from_der(data)
7  | ||         .unwrap()
   | ||_________________- temporary value created here
8  | |          .1
9  | |          .subject_alternative_name()
...  |
13 | |          .general_names
14 | |          .clone()
   | |_________________^ returns a value referencing data owned by the current function

```

#### After the patch (does compile)
No error as `.clone()` should produce a new vector bound to `'a`

#### Additional Notes
* Added another commit to fix clippy, just for sake of green CI. Feel free to skip that commit