### PR TITLE
Support aws-lc-rs alternative to ring and add ECDSAWithSha512 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x509-parser"
-version = "0.16.0"
+version = "0.16.1"
 description = "Parser for the X.509 v3 format (RFC 5280 certificates)"
 license = "MIT OR Apache-2.0"
 keywords = ["X509","Certificate","parser","nom"]
@@ -37,7 +37,9 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = []
+all = ["verify", "validate"]
 verify = ["ring"]
+verify-aws-lc = ["aws-lc-rs"]
 validate = []
 
 [dependencies]
@@ -48,6 +50,7 @@ nom = "7.0"
 oid-registry = { version="0.7", features=["crypto", "x509", "x962"] }
 rusticata-macros = "4.0"
 ring = { version="0.17.7", optional=true }
+aws-lc-rs = { version="1.6.2", optional=true}
 der-parser = { version = "9.0", features=["bigint"] }
 thiserror = "1.0.2"
 time = { version="0.3.20", features=["formatting"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,8 +152,8 @@ pub mod utils;
 #[cfg(feature = "validate")]
 #[cfg_attr(docsrs, doc(cfg(feature = "validate")))]
 pub mod validate;
-#[cfg(feature = "verify")]
-#[cfg_attr(docsrs, doc(cfg(feature = "verify")))]
+#[cfg(any(all(feature = "verify", not(feature = "verify-aws-lc")), all(not(feature = "verify"), feature = "verify-aws-lc")))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "verify", feature = "verify-aws-lc"))))]
 pub mod verify;
 pub mod x509;
 

--- a/src/x509.rs
+++ b/src/x509.rs
@@ -291,7 +291,7 @@ impl<'a> FromDer<'a, X509Error> for SubjectPublicKeyInfo<'a> {
 /// algorithm.  The OBJECT IDENTIFIER component identifies the algorithm
 /// (such as DSA with SHA-1).  The contents of the optional parameters
 /// field will vary according to the algorithm identified.
-#[derive(Clone, Debug, PartialEq, DerSequence)]
+#[derive(Clone, Debug, Eq, PartialEq, DerSequence)]
 #[error(X509Error)]
 pub struct AlgorithmIdentifier<'a> {
     #[map_err(|_| X509Error::InvalidAlgorithmIdentifier)]


### PR DESCRIPTION
Main motivation for this is I need ECDSA with SHA512 for some certs I need to verify. Problem with this is ring doesn't support it. However, aws-lc-rs, which is designed to be a drop-in replacement for ring, does support it, but it comes with a few stipulations:

- The aws-libcrypto library it's based on is written in C++
- In order to build, you have to have cmake and nasm installed

Let me know what you think.