### PR TITLE
clippy: fix new findings, add cron schedule to CI

### DIFF
--- a/.github/workflows/clippy-check.yml
+++ b/.github/workflows/clippy-check.yml
@@ -1,4 +1,9 @@
-on: push
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 18 * * *'
+
 name: Clippy check
 jobs:
   clippy_check:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,8 @@
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 18 * * *'
 
 name: Continuous integration
 

--- a/src/certificate.rs
+++ b/src/certificate.rs
@@ -15,13 +15,11 @@ use crate::x509::{
 use crate::verify::verify_signature;
 use asn1_rs::{BitString, FromDer, OptTaggedImplicit};
 use core::ops::Deref;
-use der_parser::ber::Tag;
 use der_parser::der::*;
 use der_parser::error::*;
 use der_parser::num_bigint::BigUint;
 use der_parser::*;
 use nom::{Offset, Parser};
-use oid_registry::Oid;
 use oid_registry::*;
 use std::collections::HashMap;
 use time::Duration;

--- a/src/certificate.rs
+++ b/src/certificate.rs
@@ -204,6 +204,12 @@ impl X509CertificateParser {
     }
 }
 
+impl Default for X509CertificateParser {
+    fn default() -> Self {
+        X509CertificateParser::new()
+    }
+}
+
 impl<'a> Parser<&'a [u8], X509Certificate<'a>, X509Error> for X509CertificateParser {
     fn parse(&mut self, input: &'a [u8]) -> IResult<&'a [u8], X509Certificate<'a>, X509Error> {
         parse_der_sequence_defined_g(|i, _| {
@@ -600,6 +606,12 @@ impl TbsCertificateParser {
         TbsCertificateParser {
             deep_parse_extensions,
         }
+    }
+}
+
+impl Default for TbsCertificateParser {
+    fn default() -> Self {
+        TbsCertificateParser::new()
     }
 }
 

--- a/src/certification_request.rs
+++ b/src/certification_request.rs
@@ -9,7 +9,6 @@ use crate::x509::{
 use crate::verify::verify_signature;
 use asn1_rs::{BitString, FromDer};
 use der_parser::der::*;
-use der_parser::oid::Oid;
 use der_parser::*;
 use nom::Offset;
 use std::collections::HashMap;

--- a/src/cri_attributes.rs
+++ b/src/cri_attributes.rs
@@ -28,8 +28,8 @@ impl<'a> FromDer<'a, X509Error> for X509CriAttribute<'a> {
                 return Err(Err::Error(Error::BerTypeError));
             };
 
-            let (i, parsed_attribute) = crate::cri_attributes::parser::parse_attribute(i, &oid)
-                .map_err(|_| Err::Error(Error::BerValueError))?;
+            let (i, parsed_attribute) =
+                parser::parse_attribute(i, &oid).map_err(|_| Err::Error(Error::BerValueError))?;
             let attribute = X509CriAttribute {
                 oid,
                 value: &value_start[..value_start.len() - i.len()],

--- a/src/extensions/generalname.rs
+++ b/src/extensions/generalname.rs
@@ -40,7 +40,7 @@ impl<'a> TryFrom<Any<'a>> for GeneralName<'a> {
         fn ia5str(any: Any) -> Result<&str, Err<Error>> {
             // Relax constraints from RFC here: we are expecting an IA5String, but many certificates
             // are using unicode characters
-            std::str::from_utf8(any.data).map_err(|_| nom::Err::Failure(Error::BerValueError))
+            std::str::from_utf8(any.data).map_err(|_| Err::Failure(Error::BerValueError))
         }
         let name = match any.tag().0 {
             0 => {

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -150,6 +150,12 @@ impl X509ExtensionParser {
     }
 }
 
+impl Default for X509ExtensionParser {
+    fn default() -> Self {
+        X509ExtensionParser::new()
+    }
+}
+
 impl<'a> Parser<&'a [u8], X509Extension<'a>, X509Error> for X509ExtensionParser {
     fn parse(&mut self, input: &'a [u8]) -> IResult<&'a [u8], X509Extension<'a>, X509Error> {
         parse_der_sequence_defined_g(|i, _| {

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -747,19 +747,19 @@ pub(crate) mod parser {
                     } else if let Ok(u) = seq[0].as_u32() {
                         (false, Some(u))
                     } else {
-                        return Err(nom::Err::Error(BerError::InvalidTag));
+                        return Err(Err::Error(BerError::InvalidTag));
                     }
                 }
                 2 => {
                     let ca = seq[0]
                         .as_bool()
-                        .or(Err(nom::Err::Error(BerError::InvalidLength)))?;
+                        .or(Err(Err::Error(BerError::InvalidLength)))?;
                     let pl = seq[1]
                         .as_u32()
-                        .or(Err(nom::Err::Error(BerError::InvalidLength)))?;
+                        .or(Err(Err::Error(BerError::InvalidLength)))?;
                     (ca, Some(pl))
                 }
-                _ => return Err(nom::Err::Error(BerError::InvalidLength)),
+                _ => return Err(Err::Error(BerError::InvalidLength)),
             };
             Ok((
                 rem,
@@ -769,7 +769,7 @@ pub(crate) mod parser {
                 },
             ))
         } else {
-            Err(nom::Err::Error(BerError::InvalidLength))
+            Err(Err::Error(BerError::InvalidLength))
         }
     }
 
@@ -888,7 +888,7 @@ pub(crate) mod parser {
                 .fold(0, |acc, x| acc << 8 | (x.reverse_bits() as u16));
             Ok((rem, ReasonFlags { flags }))
         } else {
-            Err(nom::Err::Failure(BerError::InvalidTag))
+            Err(Err::Failure(BerError::InvalidTag))
         }
     }
 

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -608,7 +608,6 @@ pub(crate) mod parser {
     use crate::extensions::*;
     use asn1_rs::{GeneralizedTime, ParseResult};
     use der_parser::ber::BerObject;
-    use der_parser::*;
     use lazy_static::lazy_static;
 
     type ExtParser = fn(&[u8]) -> IResult<&[u8], ParsedExtension, BerError>;

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -10,7 +10,6 @@ use der_parser::ber::parse_ber_bool;
 use der_parser::der::*;
 use der_parser::error::{BerError, BerResult};
 use der_parser::num_bigint::BigUint;
-use der_parser::oid::Oid;
 use nom::combinator::{all_consuming, complete, cut, map, map_res, opt};
 use nom::multi::{many0, many1};
 use nom::{Err, IResult, Parser};
@@ -607,14 +606,10 @@ pub struct IssuingDistributionPoint<'a> {
 
 pub(crate) mod parser {
     use crate::extensions::*;
-    use crate::time::ASN1Time;
     use asn1_rs::{GeneralizedTime, ParseResult};
     use der_parser::ber::BerObject;
-    use der_parser::error::BerError;
-    use der_parser::{oid::Oid, *};
+    use der_parser::*;
     use lazy_static::lazy_static;
-    use nom::combinator::{cut, map};
-    use nom::{Err, IResult};
 
     type ExtParser = fn(&[u8]) -> IResult<&[u8], ParsedExtension, BerError>;
 

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -19,7 +19,7 @@
 //! ```
 
 use crate::error::NidError;
-use asn1_rs::{oid, Oid};
+use asn1_rs::oid;
 use lazy_static::lazy_static;
 use oid_registry::*;
 use std::collections::HashMap;

--- a/src/pem.rs
+++ b/src/pem.rs
@@ -161,7 +161,7 @@ impl Pem {
     }
 
     /// Decode the PEM contents into a X.509 object
-    pub fn parse_x509(&self) -> Result<X509Certificate, ::nom::Err<X509Error>> {
+    pub fn parse_x509(&self) -> Result<X509Certificate, Err<X509Error>> {
         parse_x509_certificate(&self.contents).map(|(_, x509)| x509)
     }
 

--- a/src/revocation_list.rs
+++ b/src/revocation_list.rs
@@ -11,10 +11,8 @@ use crate::verify::verify_signature;
 #[cfg(feature = "verify")]
 use crate::x509::SubjectPublicKeyInfo;
 use asn1_rs::{BitString, FromDer};
-use der_parser::ber::Tag;
 use der_parser::der::*;
 use der_parser::num_bigint::BigUint;
-use der_parser::oid::Oid;
 use nom::combinator::{all_consuming, complete, map, opt};
 use nom::multi::many0;
 use nom::Offset;

--- a/src/signature_algorithm.rs
+++ b/src/signature_algorithm.rs
@@ -1,7 +1,7 @@
 use crate::error::X509Error;
 use crate::x509::AlgorithmIdentifier;
 use asn1_rs::{
-    oid, Any, CheckDerConstraints, Class, DerAutoDerive, Error, FromDer, Oid, OptTaggedExplicit,
+    oid, Any, CheckDerConstraints, Class, DerAutoDerive, Error, FromDer, OptTaggedExplicit,
     OptTaggedParser, Tag,
 };
 use core::convert::TryFrom;

--- a/src/time.rs
+++ b/src/time.rs
@@ -96,7 +96,7 @@ fn parse_malformed_date(i: &[u8]) -> ParseResult<OffsetDateTime> {
     let (_rem, hdr) = Header::from_der(i)?;
     let len = hdr.length().definite()?;
     if len > MAX_OBJECT_SIZE {
-        return Err(nom::Err::Error(Error::InvalidLength));
+        return Err(Err::Error(Error::InvalidLength));
     }
     match hdr.tag() {
         Tag::UtcTime => {
@@ -111,9 +111,9 @@ fn parse_malformed_date(i: &[u8]) -> ParseResult<OffsetDateTime> {
             // let content = BerObjectContent::UTCTime(s);
             // let obj = DerObject::from_header_and_content(hdr, content);
             // Ok((rem, obj))
-            Err(nom::Err::Error(Error::BerValueError))
+            Err(Err::Error(Error::BerValueError))
         }
-        _ => Err(nom::Err::Error(Error::unexpected_tag(None, hdr.tag()))),
+        _ => Err(Err::Error(Error::unexpected_tag(None, hdr.tag()))),
     }
 }
 

--- a/src/validate/certificate.rs
+++ b/src/validate/certificate.rs
@@ -1,8 +1,6 @@
 use crate::certificate::*;
 use crate::validate::*;
 
-use extensions::X509ExtensionsValidator;
-
 #[derive(Debug)]
 pub struct X509CertificateValidator;
 

--- a/src/x509.rs
+++ b/src/x509.rs
@@ -8,7 +8,7 @@ use crate::objects::*;
 use crate::public_key::*;
 
 use asn1_rs::{
-    Any, BitString, BmpString, DerSequence, FromBer, FromDer, Oid, OptTaggedParser, ParseResult,
+    Any, BitString, BmpString, DerSequence, FromBer, FromDer, OptTaggedParser, ParseResult,
 };
 use core::convert::TryFrom;
 use data_encoding::HEXUPPER;

--- a/src/x509.rs
+++ b/src/x509.rs
@@ -161,7 +161,7 @@ fn parse_malformed_string(i: &[u8]) -> ParseResult<Any, Error> {
     let (rem, hdr) = Header::from_der(i)?;
     let len = hdr.length().definite()?;
     if len > MAX_OBJECT_SIZE {
-        return Err(nom::Err::Error(Error::InvalidLength));
+        return Err(Err::Error(Error::InvalidLength));
     }
     match hdr.tag() {
         Tag::PrintableString => {
@@ -174,7 +174,7 @@ fn parse_malformed_string(i: &[u8]) -> ParseResult<Any, Error> {
             let obj = Any::new(hdr, data);
             Ok((rem, obj))
         }
-        t => Err(nom::Err::Error(Error::unexpected_tag(
+        t => Err(Err::Error(Error::unexpected_tag(
             Some(Tag::PrintableString),
             t,
         ))),


### PR DESCRIPTION
This branch fixes some `clippy` findings that are breaking CI for new builds ([for example](https://github.com/rusticata/x509-parser/actions/runs/8306288643/job/22734160291?pr=154)).

It also adds `schedule` cron triggers to the `clippy-checks` and `rust` workflows so that we can catch these things sooner when there isn't active development work pushing new branches on a regular cadence.