### PR TITLE
Upgrade `asn1-rs` to version 0.6.2.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ verify = ["ring"]
 validate = []
 
 [dependencies]
-asn1-rs = { version = "0.6.1", features=["datetime"] }
+asn1-rs = { version = "0.6.2", features=["datetime"] }
 data-encoding = "2.2.1"
 lazy_static = "1.4"
 nom = "7.0"


### PR DESCRIPTION
This fixes a possible panic while parsing malformed X509 certificates, as described in https://github.com/rusticata/asn1-rs/issues/40