### PR TITLE
Cargo: 0.17.0 -> 0.18.0, update cc, data-encoding, oid-registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,9 +49,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "cc"
-version = "1.2.11"
+version = "1.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4730490333d58093109dc02c23174c3f4d490998c3fed3cc8e82d57afedb9cf"
+checksum = "c7777341816418c02e033934a09f20dc0ccaf65a5201ef8a450ae0105a573fda"
 dependencies = [
  "shlex",
 ]
@@ -64,9 +64,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "data-encoding"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e60eed09d8c01d3cee5b7d30acb059b76614c918fa0f992e0dd6eeb10daad6f"
+checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
 
 [[package]]
 name = "der-parser"
@@ -189,9 +189,9 @@ dependencies = [
 
 [[package]]
 name = "oid-registry"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "264c56d1492c13e769662197fb6b94e0a52abe52d27efac374615799a4bf453d"
+checksum = "12f40cff3dde1b6087cc5d5f5d4d65712f34016a03ed60e9c08dcc392736b5b7"
 dependencies = [
  "asn1-rs",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,7 +442,7 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "x509-parser"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "asn1-rs",
  "data-encoding",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x509-parser"
-version = "0.17.0"
+version = "0.18.0"
 description = "Parser for the X.509 v3 format (RFC 5280 certificates)"
 license = "MIT OR Apache-2.0"
 keywords = ["X509","Certificate","parser","nom"]

--- a/src/certificate.rs
+++ b/src/certificate.rs
@@ -436,7 +436,7 @@ impl<'a> TbsCertificate<'a> {
     pub fn inhibit_anypolicy(
         &self,
     ) -> Result<Option<BasicExtension<&InhibitAnyPolicy>>, X509Error> {
-        self.get_extension_unique(&OID_X509_EXT_INHIBITANT_ANY_POLICY)?
+        self.get_extension_unique(&OID_X509_EXT_INHIBIT_ANY_POLICY)?
             .map_or(Ok(None), |ext| match ext.parsed_extension {
                 ParsedExtension::InhibitAnyPolicy(ref value) => {
                     Ok(Some(BasicExtension::new(ext.critical, value)))

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -672,7 +672,7 @@ pub(crate) mod parser {
             );
             add!(
                 m,
-                OID_X509_EXT_INHIBITANT_ANY_POLICY,
+                OID_X509_EXT_INHIBIT_ANY_POLICY,
                 parse_inhibitanypolicy_ext
             );
             add!(


### PR DESCRIPTION
### Cargo: 0.17.0 -> 0.18.0
This commit updates the version number to reflect that a breaking change was made in `master`. This in turn fixes the
`cargo-semver-checks-action` finding in CI.

In https://github.com/rusticata/x509-parser/commit/ce50cdb38a742dbe85a9a2f5fd79ad4caf2bf42a a new variant (`GeneralName:Invalid`) was added to `GeneralName`, and since that enum isn't marked `non_exhaustive`, this is a semver incompatible change that necessitates increasing the Cargo version.

This was correctly flagged by the [CI `cargo-semver-checks` action](https://github.com/rusticata/x509-parser/actions/runs/13118644941/job/36599085538), but since the commit was pushed directly to `master` it seems to have been overlooked.

@chifflier would you be open to switching to a pull request workflow? I would be available to try and review incoming PRs if you're interested in that, but even if you merge them yourself without review I think it's worthwhile as a way to verify CI passes pre-merge.

### Cargo: update cc, data-encoding, oid-registry

Updates 3 packages to latest compatible versions:
  Updating cc v1.2.11 -> v1.2.13
  Updating data-encoding v2.7.0 -> v2.8.0
  Updating oid-registry v0.8.0 -> v0.8.1

Notably the oid-registry update requires replacing usages of the deprecated typo'd `OID_X509_EXT_INHIBITANT_ANY_POLICY` OID with `OID_X509_EXT_INHIBIT_ANY_POLICY`.

Replaces https://github.com/rusticata/x509-parser/pull/181, #182 where I noticed the builds failling.