### PR TITLE
clippy: fix uninlined_format_args findings

### DIFF
--- a/examples/print-cert.rs
+++ b/examples/print-cert.rs
@@ -25,22 +25,22 @@ fn print_hex_dump(bytes: &[u8], max_len: usize) {
 fn format_oid(oid: &Oid) -> String {
     match oid2sn(oid, oid_registry()) {
         Ok(s) => s.to_owned(),
-        _ => format!("{}", oid),
+        _ => format!("{oid}"),
     }
 }
 
 fn generalname_to_string(gn: &GeneralName) -> String {
     match gn {
-        GeneralName::DNSName(name) => format!("DNSName:{}", name),
-        GeneralName::DirectoryName(n) => format!("DirName:{}", n),
-        GeneralName::EDIPartyName(obj) => format!("EDIPartyName:{:?}", obj),
-        GeneralName::IPAddress(n) => format!("IPAddress:{:?}", n),
-        GeneralName::OtherName(oid, n) => format!("OtherName:{}, {:?}", oid, n),
-        GeneralName::RFC822Name(n) => format!("RFC822Name:{}", n),
-        GeneralName::RegisteredID(oid) => format!("RegisteredID:{}", oid),
-        GeneralName::URI(n) => format!("URI:{}", n),
-        GeneralName::X400Address(obj) => format!("X400Address:{:?}", obj),
-        GeneralName::Invalid(tag, b) => format!("Invalid:tag={},data={:?}", tag, b),
+        GeneralName::DNSName(name) => format!("DNSName:{name}"),
+        GeneralName::DirectoryName(n) => format!("DirName:{n}"),
+        GeneralName::EDIPartyName(obj) => format!("EDIPartyName:{obj:?}"),
+        GeneralName::IPAddress(n) => format!("IPAddress:{n:?}"),
+        GeneralName::OtherName(oid, n) => format!("OtherName:{oid}, {n:?}"),
+        GeneralName::RFC822Name(n) => format!("RFC822Name:{n}"),
+        GeneralName::RegisteredID(oid) => format!("RegisteredID:{oid}"),
+        GeneralName::URI(n) => format!("URI:{n}"),
+        GeneralName::X400Address(obj) => format!("X400Address:{obj:?}"),
+        GeneralName::Invalid(tag, b) => format!("Invalid:tag={tag},data={b:?}"),
     }
 }
 
@@ -55,11 +55,11 @@ fn print_x509_extension(oid: &Oid, ext: &X509Extension) {
         ParsedExtension::AuthorityKeyIdentifier(aki) => {
             println!("      X509v3 Authority Key Identifier");
             if let Some(key_id) = &aki.key_identifier {
-                println!("        Key Identifier: {:x}", key_id);
+                println!("        Key Identifier: {key_id:x}");
             }
             if let Some(issuer) = &aki.authority_cert_issuer {
                 for name in issuer {
-                    println!("        Cert Issuer: {}", name);
+                    println!("        Cert Issuer: {name}");
                 }
             }
             if let Some(serial) = aki.authority_cert_serial {
@@ -73,10 +73,10 @@ fn print_x509_extension(oid: &Oid, ext: &X509Extension) {
             println!("      X509v3 CRL Distribution Points:");
             for point in points.iter() {
                 if let Some(name) = &point.distribution_point {
-                    println!("        Full Name: {:?}", name);
+                    println!("        Full Name: {name:?}");
                 }
                 if let Some(reasons) = &point.reasons {
-                    println!("        Reasons: {}", reasons);
+                    println!("        Reasons: {reasons}");
                 }
                 if let Some(crl_issuer) = &point.crl_issuer {
                     print!("        CRL Issuer: ");
@@ -89,44 +89,44 @@ fn print_x509_extension(oid: &Oid, ext: &X509Extension) {
             }
         }
         ParsedExtension::KeyUsage(ku) => {
-            println!("      X509v3 Key Usage: {}", ku);
+            println!("      X509v3 Key Usage: {ku}");
         }
         ParsedExtension::NSCertType(ty) => {
-            println!("      Netscape Cert Type: {}", ty);
+            println!("      Netscape Cert Type: {ty}");
         }
         ParsedExtension::SubjectAlternativeName(san) => {
             for name in &san.general_names {
                 let s = match name {
                     GeneralName::DNSName(s) => {
-                        format!("DNS:{}", s)
+                        format!("DNS:{s}")
                     }
                     GeneralName::IPAddress(b) => {
                         let ip = match b.len() {
                             4 => {
                                 let b = <[u8; 4]>::try_from(*b).unwrap();
                                 let ip = Ipv4Addr::from(b);
-                                format!("{}", ip)
+                                format!("{ip}")
                             }
                             16 => {
                                 let b = <[u8; 16]>::try_from(*b).unwrap();
                                 let ip = Ipv6Addr::from(b);
-                                format!("{}", ip)
+                                format!("{ip}")
                             }
-                            l => format!("invalid (len={})", l),
+                            l => format!("invalid (len={l})"),
                         };
-                        format!("IP Address:{}", ip)
+                        format!("IP Address:{ip}")
                     }
                     _ => {
-                        format!("{:?}", name)
+                        format!("{name:?}")
                     }
                 };
-                println!("      X509v3 SAN: {}", s);
+                println!("      X509v3 SAN: {s}");
             }
         }
         ParsedExtension::SubjectKeyIdentifier(id) => {
-            println!("      X509v3 Subject Key Identifier: {:x}", id);
+            println!("      X509v3 Subject Key Identifier: {id:x}");
         }
-        x => println!("      {:?}", x),
+        x => println!("      {x:?}"),
     }
 }
 
@@ -156,7 +156,7 @@ fn print_x509_digest_algorithm(alg: &AlgorithmIdentifier, level: usize) {
 fn print_x509_info(x509: &X509Certificate) -> io::Result<()> {
     let version = x509.version();
     if version.0 < 3 {
-        println!("  Version: {}", version);
+        println!("  Version: {version}");
     } else {
         println!("  Version: INVALID({})", version.0);
     }
@@ -173,7 +173,7 @@ fn print_x509_info(x509: &X509Certificate) -> io::Result<()> {
 
     println!("  Signature Value:");
     for l in format_number_to_hex_with_colon(&x509.signature_value.data, 16) {
-        println!("      {}", l);
+        println!("      {l}");
     }
     println!("  Extensions:");
     for ext in x509.extensions() {
@@ -194,10 +194,10 @@ fn print_x509_info(x509: &X509Certificate) -> io::Result<()> {
             println!("FAIL");
         }
         for warning in logger.warnings() {
-            println!("  [W] {}", warning);
+            println!("  [W] {warning}");
         }
         for error in logger.errors() {
-            println!("  [E] {}", error);
+            println!("  [E] {error}");
         }
         println!();
         if VALIDATE_ERRORS_FATAL && !logger.errors().is_empty() {
@@ -244,7 +244,7 @@ fn print_x509_signature_algorithm(signature_algorithm: &AlgorithmIdentifier, ind
                         indent_s,
                         format_oid(params.hash_algorithm_oid()),
                     );
-                    print!("{}Mask Generation Function: ", indent_s);
+                    print!("{indent_s}Mask Generation Function: ");
                     if let Ok(mask_gen) = params.mask_gen_algorithm() {
                         println!(
                             "{}/{}",
@@ -264,7 +264,7 @@ fn print_x509_signature_algorithm(signature_algorithm: &AlgorithmIdentifier, ind
                         indent_s,
                         format_oid(params.hash_algorithm_oid()),
                     );
-                    print!("{}Mask Generation Function: ", indent_s);
+                    print!("{indent_s}Mask Generation Function: ");
                     if let Ok(mask_gen) = params.mask_gen_algorithm() {
                         println!(
                             "{}/{}",
@@ -283,7 +283,7 @@ fn print_x509_signature_algorithm(signature_algorithm: &AlgorithmIdentifier, ind
             }
         }
         Err(e) => {
-            eprintln!("Could not parse signature algorithm: {}", e);
+            eprintln!("Could not parse signature algorithm: {e}");
             println!("  Signature Algorithm:");
             print_x509_digest_algorithm(signature_algorithm, indent);
         }
@@ -298,10 +298,10 @@ fn print_x509_ski(public_key: &SubjectPublicKeyInfo) {
             println!("    RSA Public Key: ({} bit)", rsa.key_size());
             // print_hex_dump(rsa.modulus, 1024);
             for l in format_number_to_hex_with_colon(rsa.modulus, 16) {
-                println!("        {}", l);
+                println!("        {l}");
             }
             if let Ok(e) = rsa.try_exponent() {
-                println!("    exponent: 0x{:x} ({})", e, e);
+                println!("    exponent: 0x{e:x} ({e})");
             } else {
                 println!("    exponent: <INVALID>:");
                 print_hex_dump(rsa.exponent, 32);
@@ -310,7 +310,7 @@ fn print_x509_ski(public_key: &SubjectPublicKeyInfo) {
         Ok(PublicKey::EC(ec)) => {
             println!("    EC Public Key: ({} bit)", ec.key_size());
             for l in format_number_to_hex_with_colon(ec.data(), 16) {
-                println!("        {}", l);
+                println!("        {l}");
             }
             // // identify curve
             // if let Some(params) = &public_key.algorithm.parameters {
@@ -329,19 +329,19 @@ fn print_x509_ski(public_key: &SubjectPublicKeyInfo) {
         Ok(PublicKey::DSA(y)) => {
             println!("    DSA Public Key: ({} bit)", 8 * y.len());
             for l in format_number_to_hex_with_colon(y, 16) {
-                println!("        {}", l);
+                println!("        {l}");
             }
         }
         Ok(PublicKey::GostR3410(y)) => {
             println!("    GOST R 34.10-94 Public Key: ({} bit)", 8 * y.len());
             for l in format_number_to_hex_with_colon(y, 16) {
-                println!("        {}", l);
+                println!("        {l}");
             }
         }
         Ok(PublicKey::GostR3410_2012(y)) => {
             println!("    GOST R 34.10-2012 Public Key: ({} bit)", 8 * y.len());
             for l in format_number_to_hex_with_colon(y, 16) {
-                println!("        {}", l);
+                println!("        {l}");
             }
         }
         Ok(PublicKey::Unknown(b)) => {
@@ -349,7 +349,7 @@ fn print_x509_ski(public_key: &SubjectPublicKeyInfo) {
             print_hex_dump(b, 256);
             if let Ok((rem, res)) = der_parser::parse_der(b) {
                 eprintln!("rem: {} bytes", rem.len());
-                eprintln!("{:?}", res);
+                eprintln!("{res:?}");
             } else {
                 eprintln!("      <Could not parse key as DER>");
             }
@@ -366,7 +366,7 @@ fn format_number_to_hex_with_colon(b: &[u8], row_size: usize) -> Vec<String> {
     let mut v = Vec::with_capacity(1 + b.len() / row_size);
     for r in b.chunks(row_size) {
         let s = r.iter().fold(String::with_capacity(3 * r.len()), |a, b| {
-            a + &format!("{:02x}:", b)
+            a + &format!("{b:02x}:")
         });
         v.push(s)
     }
@@ -380,11 +380,11 @@ fn handle_certificate(file_name: &str, data: &[u8]) -> io::Result<()> {
             Ok(())
         }
         Err(e) => {
-            let s = format!("Error while parsing {}: {}", file_name, e);
+            let s = format!("Error while parsing {file_name}: {e}");
             if PARSE_ERRORS_FATAL {
                 Err(io::Error::new(io::ErrorKind::Other, s))
             } else {
-                eprintln!("{}", s);
+                eprintln!("{s}");
                 Ok(())
             }
         }
@@ -393,7 +393,7 @@ fn handle_certificate(file_name: &str, data: &[u8]) -> io::Result<()> {
 
 pub fn main() -> io::Result<()> {
     for file_name in env::args().skip(1) {
-        println!("File: {}", file_name);
+        println!("File: {file_name}");
         let data = std::fs::read(file_name.clone()).expect("Unable to read file");
         if matches!((data[0], data[1]), (0x30, 0x81..=0x83)) {
             // probably DER
@@ -404,11 +404,11 @@ pub fn main() -> io::Result<()> {
                 match pem {
                     Ok(pem) => {
                         let data = &pem.contents;
-                        println!("Certificate [{}]", n);
+                        println!("Certificate [{n}]");
                         handle_certificate(&file_name, data)?;
                     }
                     Err(e) => {
-                        eprintln!("Error while decoding PEM entry {}: {}", n, e);
+                        eprintln!("Error while decoding PEM entry {n}: {e}");
                     }
                 }
             }

--- a/examples/print-crl.rs
+++ b/examples/print-crl.rs
@@ -16,7 +16,7 @@ fn print_hex_dump(bytes: &[u8], max_len: usize) {
 fn format_oid(oid: &Oid) -> String {
     match oid2sn(oid, oid_registry()) {
         Ok(s) => s.to_owned(),
-        _ => format!("{}", oid),
+        _ => format!("{oid}"),
     }
 }
 
@@ -136,7 +136,7 @@ pub fn main() -> io::Result<()> {
         // placeholder to store decoded PEM data, if needed
         let tmpdata;
 
-        println!("File: {}", file_name);
+        println!("File: {file_name}");
         let data = std::fs::read(file_name.clone()).expect("Unable to read file");
         let der_data: &[u8] = if (data[0], data[1]) == (0x30, 0x82) {
             // probably DER

--- a/src/extensions/generalname.rs
+++ b/src/extensions/generalname.rs
@@ -102,15 +102,15 @@ impl<'a> FromDer<'a, X509Error> for GeneralName<'a> {
 impl fmt::Display for GeneralName<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            GeneralName::OtherName(oid, _) => write!(f, "OtherName({}, [...])", oid),
-            GeneralName::RFC822Name(s) => write!(f, "RFC822Name({})", s),
-            GeneralName::DNSName(s) => write!(f, "DNSName({})", s),
+            GeneralName::OtherName(oid, _) => write!(f, "OtherName({oid}, [...])"),
+            GeneralName::RFC822Name(s) => write!(f, "RFC822Name({s})"),
+            GeneralName::DNSName(s) => write!(f, "DNSName({s})"),
             GeneralName::X400Address(_) => write!(f, "X400Address(<unparsed>)"),
-            GeneralName::DirectoryName(dn) => write!(f, "DirectoryName({})", dn),
+            GeneralName::DirectoryName(dn) => write!(f, "DirectoryName({dn})"),
             GeneralName::EDIPartyName(_) => write!(f, "EDIPartyName(<unparsed>)"),
-            GeneralName::URI(s) => write!(f, "URI({})", s),
+            GeneralName::URI(s) => write!(f, "URI({s})"),
             GeneralName::IPAddress(b) => write!(f, "IPAddress({})", format_serial(b)),
-            GeneralName::RegisteredID(oid) => write!(f, "RegisteredID({})", oid),
+            GeneralName::RegisteredID(oid) => write!(f, "RegisteredID({oid})"),
             GeneralName::Invalid(tag, b) => {
                 write!(f, "Invalid(tag={}, data={})", tag, format_serial(b))
             }

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -1590,7 +1590,7 @@ mod tests {
                 assert!(!reasons.privelege_withdrawn());
                 assert!(reasons.aa_compromise());
                 assert_eq!(
-                    format!("{}", reasons),
+                    format!("{reasons}"),
                     "Key Compromise, CA Compromise, AA Compromise"
                 );
                 let issuers = crl[0].crl_issuer.as_ref().unwrap();
@@ -1621,7 +1621,7 @@ mod tests {
                 assert!(!reasons.certificate_hold());
                 assert!(!reasons.privelege_withdrawn());
                 assert!(!reasons.aa_compromise());
-                assert_eq!(format!("{}", reasons), "Key Compromise, CA Compromise");
+                assert_eq!(format!("{reasons}"), "Key Compromise, CA Compromise");
                 assert!(crl[1].crl_issuer.is_none());
                 let distribution_point = crl[1].distribution_point.as_ref().unwrap();
                 assert!(matches!(

--- a/src/time.rs
+++ b/src/time.rs
@@ -164,7 +164,7 @@ impl fmt::Display for ASN1Time {
         let s = self
             .time
             .format(format)
-            .unwrap_or_else(|e| format!("Invalid date: {}", e));
+            .unwrap_or_else(|e| format!("Invalid date: {e}"));
         f.write_str(&s)
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,7 @@
 /// Formats a slice to a colon-separated hex string (for ex `01:02:ff:ff`)
 pub fn format_serial(i: &[u8]) -> String {
     let mut s = i.iter().fold(String::with_capacity(3 * i.len()), |a, b| {
-        a + &format!("{:02x}:", b)
+        a + &format!("{b:02x}:")
     });
     s.pop();
     s

--- a/src/validate/extensions.rs
+++ b/src/validate/extensions.rs
@@ -100,7 +100,7 @@ impl<'a> Validator<'a> for X509ExtensionsValidator {
                             GeneralName::DNSName(ref s) | GeneralName::RFC822Name(ref s) => {
                                 // should be an ia5string
                                 if !s.as_bytes().iter().all(u8::is_ascii) {
-                                    l.warn(&format!("Invalid charset in 'SAN' entry '{}'", s));
+                                    l.warn(&format!("Invalid charset in 'SAN' entry '{s}'"));
                                 }
                             }
                             _ => (),

--- a/src/validate/loggers.rs
+++ b/src/validate/loggers.rs
@@ -39,11 +39,11 @@ pub struct StderrLogger;
 
 impl Logger for StderrLogger {
     fn warn(&mut self, message: &str) {
-        eprintln!("[W] {}", message);
+        eprintln!("[W] {message}");
     }
 
     fn err(&mut self, message: &str) {
-        eprintln!("[E] {}", message);
+        eprintln!("[E] {message}");
     }
 }
 

--- a/src/validate/structure.rs
+++ b/src/validate/structure.rs
@@ -143,7 +143,7 @@ impl<'a> Validator<'a> for TbsCertificateStructureValidator {
                         GeneralName::DNSName(ref s) | GeneralName::RFC822Name(ref s) => {
                             // should be an ia5string
                             if !s.as_bytes().iter().all(u8::is_ascii) {
-                                l.warn(&format!("Invalid charset in 'SAN' entry '{}'", s));
+                                l.warn(&format!("Invalid charset in 'SAN' entry '{s}'"));
                             }
                         }
                         _ => (),

--- a/src/x509.rs
+++ b/src/x509.rs
@@ -335,7 +335,7 @@ pub struct X509Name<'a> {
 impl fmt::Display for X509Name<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match x509name_to_string(&self.rdn_seq, oid_registry()) {
-            Ok(o) => write!(f, "{}", o),
+            Ok(o) => write!(f, "{o}"),
             Err(_) => write!(f, "<X509Error: Invalid X.509 name>"),
         }
     }
@@ -558,7 +558,7 @@ fn x509name_to_string(
                     Ok(s) => String::from(s),
                     _ => format!("{:?}", attr.attr_type),
                 };
-                let rdn = format!("{}={}", abbrev, val_str);
+                let rdn = format!("{abbrev}={val_str}");
                 match acc2.len() {
                     0 => Ok(rdn),
                     _ => Ok(acc2 + " + " + &rdn),

--- a/tests/readcrl.rs
+++ b/tests/readcrl.rs
@@ -9,7 +9,7 @@ fn read_crl_verify() {
     let (_, x509_ca) = X509Certificate::from_der(CA_DATA).expect("could not parse certificate");
     let (_, crl) = parse_x509_crl(CRL_DATA).expect("could not parse revocation list");
     let res = crl.verify_signature(&x509_ca.tbs_certificate.subject_pki);
-    eprintln!("Verification: {:?}", res);
+    eprintln!("Verification: {res:?}");
     assert!(res.is_ok());
 }
 

--- a/tests/verify.rs
+++ b/tests/verify.rs
@@ -11,7 +11,7 @@ fn test_signature_verification() {
     // for a root CA, verify self-signature
     let (_, x509_ca) = parse_x509_certificate(CA_DER).expect("could not parse certificate");
     let res = x509_ca.verify_signature(None);
-    eprintln!("Verification: {:?}", res);
+    eprintln!("Verification: {res:?}");
     assert!(res.is_ok());
 
     // for a standard certificate, first load the authority, then the certificate, and verify it
@@ -19,7 +19,7 @@ fn test_signature_verification() {
         parse_x509_certificate(CA_LETSENCRYPT_X3).expect("could not parse certificate");
     let (_, x509_cert) = parse_x509_certificate(CERT_DER).expect("could not parse certificate");
     let res = x509_cert.verify_signature(Some(&x509_ca.tbs_certificate.subject_pki));
-    eprintln!("Verification: {:?}", res);
+    eprintln!("Verification: {res:?}");
     assert!(res.is_ok());
 }
 
@@ -30,7 +30,7 @@ fn test_signature_verification_ed25519() {
     // this certificate is self-signed
     let (_, x509_ca) = parse_x509_certificate(ED25519_DER).expect("could not parse certificate");
     let res = x509_ca.verify_signature(None);
-    eprintln!("Verification: {:?}", res);
+    eprintln!("Verification: {res:?}");
     assert!(res.is_ok());
 }
 
@@ -46,7 +46,7 @@ fn test_signature_verification_rsa_pss_sha256() {
     let (_, x509) =
         parse_x509_certificate(RSA_PSS_SELF_SIGNED_SHA256).expect("could not parse certificate");
     let res = x509.verify_signature(None);
-    eprintln!("Verification: {:?}", res);
+    eprintln!("Verification: {res:?}");
     assert!(res.is_ok());
 }
 
@@ -55,7 +55,7 @@ fn test_signature_verification_rsa_pss_sha384() {
     let (_, x509) =
         parse_x509_certificate(RSA_PSS_SELF_SIGNED_SHA384).expect("could not parse certificate");
     let res = x509.verify_signature(None);
-    eprintln!("Verification: {:?}", res);
+    eprintln!("Verification: {res:?}");
     assert!(res.is_ok());
 }
 
@@ -64,6 +64,6 @@ fn test_signature_verification_rsa_pss_sha512() {
     let (_, x509) =
         parse_x509_certificate(RSA_PSS_SELF_SIGNED_SHA512).expect("could not parse certificate");
     let res = x509.verify_signature(None);
-    eprintln!("Verification: {:?}", res);
+    eprintln!("Verification: {res:?}");
     assert!(res.is_ok());
 }


### PR DESCRIPTION
Applies the result of `cargo clippy --fix` for findings of the form:

```
warning: variables can be used directly in the `format!` string
   --> src/extensions/generalname.rs:105:47
    |
105 |             GeneralName::OtherName(oid, _) => write!(f, "OtherName({}, [...])", oid),
    |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
    = note: `#[warn(clippy::uninlined_format_args)]` on by default
help: change this to
    |
105 -             GeneralName::OtherName(oid, _) => write!(f, "OtherName({}, [...])", oid),
105 +             GeneralName::OtherName(oid, _) => write!(f, "OtherName({oid}, [...])"),
```