### PR TITLE
remove lazy_static dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,12 +133,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -467,7 +461,6 @@ dependencies = [
  "asn1-rs",
  "data-encoding",
  "hex-literal",
- "lazy_static",
  "nom",
  "oid-registry",
  "ring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/rusticata/x509-parser.git"
 categories = ["parser-implementations", "cryptography"]
 readme = "README.md"
 edition = "2018"
-rust-version = "1.67.1"
+rust-version = "1.80.0"
 
 include = [
   "CHANGELOG.md",
@@ -44,7 +44,6 @@ validate = []
 [dependencies]
 asn1-rs = { version = "0.8.0-beta.1", features=["bigint", "datetime"] }
 data-encoding = "2.2.1"
-lazy_static = "1.4"
 nom = "8.0"
 oid-registry = { version="0.9.0-beta.1", features=["crypto", "x509", "x962"] }
 rusticata-macros = "5.0"

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -331,94 +331,93 @@ impl ParsedExtension<'_> {
 }
 
 pub(crate) mod parser {
+    use std::sync::LazyLock;
+
     use crate::extensions::*;
     use asn1_rs::{GeneralizedTime, Integer};
-    use lazy_static::lazy_static;
 
     type ExtParser = fn(Input) -> IResult<Input, ParsedExtension, X509Error>;
 
-    lazy_static! {
-        static ref EXTENSION_PARSERS: HashMap<Oid<'static>, ExtParser> = {
-            macro_rules! add {
-                ($m:ident, $oid:ident, $p:ident) => {
-                    $m.insert($oid, $p as ExtParser);
-                };
-            }
+    static EXTENSION_PARSERS: LazyLock<HashMap<Oid<'static>, ExtParser>> = LazyLock::new(|| {
+        macro_rules! add {
+            ($m:ident, $oid:ident, $p:ident) => {
+                $m.insert($oid, $p as ExtParser);
+            };
+        }
 
-            let mut m = HashMap::new();
-            add!(
-                m,
-                OID_X509_EXT_SUBJECT_KEY_IDENTIFIER,
-                parse_keyidentifier_ext
-            );
-            add!(m, OID_X509_EXT_KEY_USAGE, parse_keyusage_ext);
-            add!(
-                m,
-                OID_X509_EXT_SUBJECT_ALT_NAME,
-                parse_subjectalternativename_ext
-            );
-            add!(
-                m,
-                OID_X509_EXT_ISSUER_ALT_NAME,
-                parse_issueralternativename_ext
-            );
-            add!(
-                m,
-                OID_X509_EXT_BASIC_CONSTRAINTS,
-                parse_basicconstraints_ext
-            );
-            add!(m, OID_X509_EXT_NAME_CONSTRAINTS, parse_nameconstraints_ext);
-            add!(
-                m,
-                OID_X509_EXT_CERTIFICATE_POLICIES,
-                parse_certificatepolicies_ext
-            );
-            add!(m, OID_X509_EXT_POLICY_MAPPINGS, parse_policymappings_ext);
-            add!(
-                m,
-                OID_X509_EXT_POLICY_CONSTRAINTS,
-                parse_policyconstraints_ext
-            );
-            add!(
-                m,
-                OID_X509_EXT_EXTENDED_KEY_USAGE,
-                parse_extendedkeyusage_ext
-            );
-            add!(
-                m,
-                OID_X509_EXT_CRL_DISTRIBUTION_POINTS,
-                parse_crldistributionpoints_ext
-            );
-            add!(
-                m,
-                OID_X509_EXT_INHIBIT_ANY_POLICY,
-                parse_inhibitanypolicy_ext
-            );
-            add!(
-                m,
-                OID_PKIX_AUTHORITY_INFO_ACCESS,
-                parse_authorityinfoaccess_ext
-            );
-            add!(m, OID_PKIX_SUBJECT_INFO_ACCESS, parse_subjectinfoaccess_ext);
-            add!(
-                m,
-                OID_X509_EXT_AUTHORITY_KEY_IDENTIFIER,
-                parse_authoritykeyidentifier_ext
-            );
-            add!(m, OID_CT_LIST_SCT, parse_sct_ext);
-            add!(m, OID_X509_EXT_CERT_TYPE, parse_nscerttype_ext);
-            add!(m, OID_X509_EXT_CERT_COMMENT, parse_nscomment_ext);
-            add!(m, OID_X509_EXT_CRL_NUMBER, parse_crl_number);
-            add!(m, OID_X509_EXT_REASON_CODE, parse_reason_code);
-            add!(m, OID_X509_EXT_INVALIDITY_DATE, parse_invalidity_date);
-            add!(
-                m,
-                OID_X509_EXT_ISSUER_DISTRIBUTION_POINT,
-                parse_issuingdistributionpoint_ext
-            );
-            m
-        };
-    }
+        let mut m = HashMap::new();
+        add!(
+            m,
+            OID_X509_EXT_SUBJECT_KEY_IDENTIFIER,
+            parse_keyidentifier_ext
+        );
+        add!(m, OID_X509_EXT_KEY_USAGE, parse_keyusage_ext);
+        add!(
+            m,
+            OID_X509_EXT_SUBJECT_ALT_NAME,
+            parse_subjectalternativename_ext
+        );
+        add!(
+            m,
+            OID_X509_EXT_ISSUER_ALT_NAME,
+            parse_issueralternativename_ext
+        );
+        add!(
+            m,
+            OID_X509_EXT_BASIC_CONSTRAINTS,
+            parse_basicconstraints_ext
+        );
+        add!(m, OID_X509_EXT_NAME_CONSTRAINTS, parse_nameconstraints_ext);
+        add!(
+            m,
+            OID_X509_EXT_CERTIFICATE_POLICIES,
+            parse_certificatepolicies_ext
+        );
+        add!(m, OID_X509_EXT_POLICY_MAPPINGS, parse_policymappings_ext);
+        add!(
+            m,
+            OID_X509_EXT_POLICY_CONSTRAINTS,
+            parse_policyconstraints_ext
+        );
+        add!(
+            m,
+            OID_X509_EXT_EXTENDED_KEY_USAGE,
+            parse_extendedkeyusage_ext
+        );
+        add!(
+            m,
+            OID_X509_EXT_CRL_DISTRIBUTION_POINTS,
+            parse_crldistributionpoints_ext
+        );
+        add!(
+            m,
+            OID_X509_EXT_INHIBIT_ANY_POLICY,
+            parse_inhibitanypolicy_ext
+        );
+        add!(
+            m,
+            OID_PKIX_AUTHORITY_INFO_ACCESS,
+            parse_authorityinfoaccess_ext
+        );
+        add!(m, OID_PKIX_SUBJECT_INFO_ACCESS, parse_subjectinfoaccess_ext);
+        add!(
+            m,
+            OID_X509_EXT_AUTHORITY_KEY_IDENTIFIER,
+            parse_authoritykeyidentifier_ext
+        );
+        add!(m, OID_CT_LIST_SCT, parse_sct_ext);
+        add!(m, OID_X509_EXT_CERT_TYPE, parse_nscerttype_ext);
+        add!(m, OID_X509_EXT_CERT_COMMENT, parse_nscomment_ext);
+        add!(m, OID_X509_EXT_CRL_NUMBER, parse_crl_number);
+        add!(m, OID_X509_EXT_REASON_CODE, parse_reason_code);
+        add!(m, OID_X509_EXT_INVALIDITY_DATE, parse_invalidity_date);
+        add!(
+            m,
+            OID_X509_EXT_ISSUER_DISTRIBUTION_POINT,
+            parse_issuingdistributionpoint_ext
+        );
+        m
+    });
 
     // look into the parser map if the extension is known, and parse it
     // otherwise, leave it as UnsupportedExtension

--- a/src/objects.rs
+++ b/src/objects.rs
@@ -20,31 +20,28 @@
 
 use crate::error::NidError;
 use asn1_rs::oid;
-use lazy_static::lazy_static;
 use oid_registry::*;
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::LazyLock};
 
-lazy_static! {
-    static ref OID_REGISTRY: OidRegistry<'static> = {
-        let mut reg = OidRegistry::default().with_all_crypto().with_x509();
-        // OIDs not in the default registry can be added here
-        let entry = OidEntry::new("id-mgf1", "Mask Generator Function 1 (MGF1)");
-        reg.insert(oid! {1.2.840.113549.1.1.8}, entry);
-        reg
-    };
-    static ref ABBREV_MAP: HashMap<Oid<'static>, &'static str> = {
-        let mut m = HashMap::new();
-        m.insert(OID_X509_COMMON_NAME, "CN");
-        m.insert(OID_X509_COUNTRY_NAME, "C");
-        m.insert(OID_X509_LOCALITY_NAME, "L");
-        m.insert(OID_X509_STATE_OR_PROVINCE_NAME, "ST");
-        m.insert(OID_X509_ORGANIZATION_NAME, "O");
-        m.insert(OID_X509_ORGANIZATIONAL_UNIT, "OU");
-        m.insert(OID_DOMAIN_COMPONENT, "DC");
-        m.insert(OID_PKCS9_EMAIL_ADDRESS, "Email");
-        m
-    };
-}
+static OID_REGISTRY: LazyLock<OidRegistry<'static>> = LazyLock::new(|| {
+    let mut reg = OidRegistry::default().with_all_crypto().with_x509();
+    // OIDs not in the default registry can be added here
+    let entry = OidEntry::new("id-mgf1", "Mask Generator Function 1 (MGF1)");
+    reg.insert(oid! {1.2.840.113549.1.1.8}, entry);
+    reg
+});
+static ABBREV_MAP: LazyLock<HashMap<Oid<'static>, &'static str>> = LazyLock::new(|| {
+    let mut m = HashMap::new();
+    m.insert(OID_X509_COMMON_NAME, "CN");
+    m.insert(OID_X509_COUNTRY_NAME, "C");
+    m.insert(OID_X509_LOCALITY_NAME, "L");
+    m.insert(OID_X509_STATE_OR_PROVINCE_NAME, "ST");
+    m.insert(OID_X509_ORGANIZATION_NAME, "O");
+    m.insert(OID_X509_ORGANIZATIONAL_UNIT, "OU");
+    m.insert(OID_DOMAIN_COMPONENT, "DC");
+    m.insert(OID_PKCS9_EMAIL_ADDRESS, "Email");
+    m
+});
 
 /// Return the abbreviation (for ex. CN for Common Name), or if not found, the OID short name
 pub fn oid2abbrev<'a>(oid: &'a Oid, registry: &'a OidRegistry) -> Result<&'a str, NidError> {


### PR DESCRIPTION
Lazy primitives are now available in std, let's use them.

This is breaking the MSRV, but when this crate bumps it's done.