### PR TITLE
Dev/fix clippy warnings v0.2

### DIFF
--- a/src/certificate.rs
+++ b/src/certificate.rs
@@ -341,13 +341,13 @@ impl<'a> TbsCertificate<'a> {
 
     /// Get the certificate subject.
     #[inline]
-    pub fn subject(&self) -> &X509Name {
+    pub fn subject(&self) -> &X509Name<'_> {
         &self.subject
     }
 
     /// Get the certificate issuer.
     #[inline]
-    pub fn issuer(&self) -> &X509Name {
+    pub fn issuer(&self) -> &X509Name<'_> {
         &self.issuer
     }
 
@@ -359,7 +359,7 @@ impl<'a> TbsCertificate<'a> {
 
     /// Get the certificate public key information.
     #[inline]
-    pub fn public_key(&self) -> &SubjectPublicKeyInfo {
+    pub fn public_key(&self) -> &SubjectPublicKeyInfo<'_> {
         &self.subject_pki
     }
 
@@ -406,7 +406,7 @@ impl<'a> TbsCertificate<'a> {
     /// Builds and returns a map of extensions.
     ///
     /// If an extension is present twice, this will fail and return `DuplicateExtensions`.
-    pub fn extensions_map(&self) -> Result<HashMap<Oid, &X509Extension<'a>>, X509Error> {
+    pub fn extensions_map(&self) -> Result<HashMap<Oid<'_>, &X509Extension<'a>>, X509Error> {
         self.extensions
             .iter()
             .try_fold(HashMap::new(), |mut m, ext| {
@@ -456,7 +456,7 @@ impl<'a> TbsCertificate<'a> {
     /// or an error if the extension is invalid, or is present twice or more.
     pub fn extended_key_usage(
         &self,
-    ) -> Result<Option<BasicExtension<&ExtendedKeyUsage>>, X509Error> {
+    ) -> Result<Option<BasicExtension<&ExtendedKeyUsage<'_>>>, X509Error> {
         self.get_extension_unique(&OID_X509_EXT_EXTENDED_KEY_USAGE)?
             .map_or(Ok(None), |ext| match ext.parsed_extension {
                 ParsedExtension::ExtendedKeyUsage(ref value) => {
@@ -502,7 +502,9 @@ impl<'a> TbsCertificate<'a> {
     ///
     /// Return `Ok(Some(extension))` if exactly one was found, `Ok(None)` if none was found,
     /// or an error if the extension is invalid, or is present twice or more.
-    pub fn policy_mappings(&self) -> Result<Option<BasicExtension<&PolicyMappings>>, X509Error> {
+    pub fn policy_mappings(
+        &self,
+    ) -> Result<Option<BasicExtension<&PolicyMappings<'_>>>, X509Error> {
         self.get_extension_unique(&OID_X509_EXT_POLICY_MAPPINGS)?
             .map_or(Ok(None), |ext| match ext.parsed_extension {
                 ParsedExtension::PolicyMappings(ref value) => {
@@ -532,7 +534,9 @@ impl<'a> TbsCertificate<'a> {
     ///
     /// Return `Ok(Some(extension))` if exactly one was found, `Ok(None)` if none was found,
     /// or an error if the extension is invalid, or is present twice or more.
-    pub fn name_constraints(&self) -> Result<Option<BasicExtension<&NameConstraints>>, X509Error> {
+    pub fn name_constraints(
+        &self,
+    ) -> Result<Option<BasicExtension<&NameConstraints<'_>>>, X509Error> {
         self.get_extension_unique(&OID_X509_EXT_NAME_CONSTRAINTS)?
             .map_or(Ok(None), |ext| match ext.parsed_extension {
                 ParsedExtension::NameConstraints(ref value) => {

--- a/src/certification_request.rs
+++ b/src/certification_request.rs
@@ -41,7 +41,7 @@ impl X509CertificationRequest<'_> {
     /// The returned iterator can be empty.
     ///
     /// _Note_: only successfully parsed values are returned (invalid extensions are *not* returned)
-    pub fn requested_extensions(&self) -> impl Iterator<Item = &ParsedExtension> {
+    pub fn requested_extensions(&self) -> impl Iterator<Item = &ParsedExtension<'_>> {
         // iterator on all attribute, and flatten for each value of attribute
         self.certification_request_info
             .iter_attributes()
@@ -126,27 +126,27 @@ pub struct X509CertificationRequestInfo<'a> {
 impl X509CertificationRequestInfo<'_> {
     /// Get the CRL entry extensions.
     #[inline]
-    pub fn attributes(&self) -> &[X509CriAttribute] {
+    pub fn attributes(&self) -> &[X509CriAttribute<'_>] {
         &self.attributes
     }
 
     /// Returns an iterator over the CRL entry extensions
     #[inline]
-    pub fn iter_attributes(&self) -> impl Iterator<Item = &X509CriAttribute> {
+    pub fn iter_attributes(&self) -> impl Iterator<Item = &X509CriAttribute<'_>> {
         self.attributes.iter()
     }
 
     /// Searches for a CRL entry extension with the given `Oid`.
     ///
     /// Note: if there are several extensions with the same `Oid`, the first one is returned.
-    pub fn find_attribute(&self, oid: &Oid) -> Option<&X509CriAttribute> {
+    pub fn find_attribute(&self, oid: &Oid) -> Option<&X509CriAttribute<'_>> {
         self.attributes.iter().find(|&ext| ext.oid == *oid)
     }
 
     /// Builds and returns a map of CRL entry extensions.
     ///
     /// If an extension is present twice, this will fail and return `DuplicateExtensions`.
-    pub fn attributes_map(&self) -> Result<HashMap<Oid, &X509CriAttribute>, X509Error> {
+    pub fn attributes_map(&self) -> Result<HashMap<Oid<'_>, &X509CriAttribute<'_>>, X509Error> {
         self.attributes
             .iter()
             .try_fold(HashMap::new(), |mut m, ext| {

--- a/src/extensions/generalname.rs
+++ b/src/extensions/generalname.rs
@@ -168,7 +168,7 @@ impl fmt::Display for GeneralName<'_> {
     }
 }
 
-fn ia5str_relaxed(input: Input) -> Result<(Input, &str), Err<X509Error>> {
+fn ia5str_relaxed(input: Input<'_>) -> Result<(Input<'_>, &str), Err<X509Error>> {
     let (rem, input) = input.take_split(input.input_len());
     // Relax constraints from RFC here: we are expecting an IA5String, but many certificates
     // are using unicode characters

--- a/src/extensions/ns_comment.rs
+++ b/src/extensions/ns_comment.rs
@@ -5,7 +5,7 @@ use crate::error::X509Error;
 
 /// The value is an IA5String representing a comment
 /// that may be displayed to the user when the certificate is viewed
-pub fn parse_der_nscomment(input: Input) -> IResult<Input, &str, X509Error> {
+pub fn parse_der_nscomment(input: Input<'_>) -> IResult<Input<'_>, &str, X509Error> {
     match Ia5String::parse_der(input.clone()) {
         Ok((rem, obj)) => {
             let s = obj

--- a/src/extensions/sct.rs
+++ b/src/extensions/sct.rs
@@ -70,7 +70,7 @@ pub fn parse_ct_signed_certificate_timestamp_list(
 /// Parses as single Signed Certificate Timestamp entry
 pub fn parse_ct_signed_certificate_timestamp(
     i: &[u8],
-) -> IResult<&[u8], SignedCertificateTimestamp, Error> {
+) -> IResult<&[u8], SignedCertificateTimestamp<'_>, Error> {
     map_parser(
         length_data(be_u16),
         parse_ct_signed_certificate_timestamp_content,
@@ -80,7 +80,7 @@ pub fn parse_ct_signed_certificate_timestamp(
 
 pub(crate) fn parse_ct_signed_certificate_timestamp_content(
     i: &[u8],
-) -> IResult<&[u8], SignedCertificateTimestamp, Error> {
+) -> IResult<&[u8], SignedCertificateTimestamp<'_>, Error> {
     let (i, version) = be_u8(i)?;
     let (i, id) = parse_log_id(i)?;
     let (i, timestamp) = be_u64(i)?;
@@ -97,7 +97,7 @@ pub(crate) fn parse_ct_signed_certificate_timestamp_content(
 }
 
 // Safety: cannot fail, take() returns exactly 32 bytes
-fn parse_log_id(i: &[u8]) -> IResult<&[u8], CtLogID, Error> {
+fn parse_log_id(i: &[u8]) -> IResult<&[u8], CtLogID<'_>, Error> {
     let (i, key_id) = take(32usize)(i)?;
     Ok((
         i,
@@ -109,13 +109,13 @@ fn parse_log_id(i: &[u8]) -> IResult<&[u8], CtLogID, Error> {
     ))
 }
 
-fn parse_ct_extensions(i: &[u8]) -> IResult<&[u8], CtExtensions, Error> {
+fn parse_ct_extensions(i: &[u8]) -> IResult<&[u8], CtExtensions<'_>, Error> {
     let (i, ext_len) = be_u16(i)?;
     let (i, ext_data) = take(ext_len as usize)(i)?;
     Ok((i, CtExtensions(ext_data)))
 }
 
-fn parse_digitally_signed(i: &[u8]) -> IResult<&[u8], DigitallySigned, Error> {
+fn parse_digitally_signed(i: &[u8]) -> IResult<&[u8], DigitallySigned<'_>, Error> {
     let (i, hash_alg_id) = be_u8(i)?;
     let (i, sign_alg_id) = be_u8(i)?;
     let (i, data) = length_data(be_u16).parse(i)?;

--- a/src/extensions/subject_alt_name.rs
+++ b/src/extensions/subject_alt_name.rs
@@ -19,7 +19,7 @@ use super::{GeneralName, GeneralNames};
 pub struct SubjectAlternativeName<'a>(pub GeneralNames<'a>);
 
 impl SubjectAlternativeName<'_> {
-    pub fn general_names(&self) -> impl Iterator<Item = &GeneralName> {
+    pub fn general_names(&self) -> impl Iterator<Item = &GeneralName<'_>> {
         self.0.iter()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,7 +176,7 @@ use revocation_list::CertificateRevocationList;
 ///
 /// For PEM-encoded certificates, use the [`pem`](pem/index.html) module.
 #[inline]
-pub fn parse_x509_certificate(i: &[u8]) -> X509Result<X509Certificate> {
+pub fn parse_x509_certificate(i: &[u8]) -> X509Result<'_, X509Certificate<'_>> {
     X509Certificate::from_der(i)
 }
 
@@ -186,7 +186,7 @@ pub fn parse_x509_certificate(i: &[u8]) -> X509Result<X509Certificate> {
 /// This function is an alias to [CertificateRevocationList::from_der](revocation_list::CertificateRevocationList::from_der). See this function
 /// for more information.
 #[inline]
-pub fn parse_x509_crl(i: &[u8]) -> X509Result<CertificateRevocationList> {
+pub fn parse_x509_crl(i: &[u8]) -> X509Result<'_, CertificateRevocationList<'_>> {
     CertificateRevocationList::from_der(i)
 }
 
@@ -196,7 +196,7 @@ pub fn parse_x509_crl(i: &[u8]) -> X509Result<CertificateRevocationList> {
     note = "please use `parse_x509_certificate` or `X509Certificate::from_der` instead"
 )]
 #[inline]
-pub fn parse_x509_der(i: &[u8]) -> X509Result<X509Certificate> {
+pub fn parse_x509_der(i: &[u8]) -> X509Result<'_, X509Certificate<'_>> {
     X509Certificate::from_der(i)
 }
 
@@ -207,6 +207,6 @@ pub fn parse_x509_der(i: &[u8]) -> X509Result<X509Certificate> {
     note = "please use `parse_x509_crl` or `CertificateRevocationList::from_der` instead"
 )]
 #[inline]
-pub fn parse_crl_der(i: &[u8]) -> X509Result<CertificateRevocationList> {
+pub fn parse_crl_der(i: &[u8]) -> X509Result<'_, CertificateRevocationList<'_>> {
     CertificateRevocationList::from_der(i)
 }

--- a/src/pem.rs
+++ b/src/pem.rs
@@ -170,7 +170,7 @@ impl Pem {
     }
 
     /// Decode the PEM contents into a X.509 object
-    pub fn parse_x509(&self) -> Result<X509Certificate, Err<X509Error>> {
+    pub fn parse_x509(&self) -> Result<X509Certificate<'_>, Err<X509Error>> {
         parse_x509_certificate(&self.contents).map(|(_, x509)| x509)
     }
 

--- a/src/public_key.rs
+++ b/src/public_key.rs
@@ -69,7 +69,7 @@ impl RSAPublicKey<'_> {
     }
 }
 
-fn parse_rsa_key(bytes: &[u8]) -> IResult<&[u8], RSAPublicKey, X509Error> {
+fn parse_rsa_key(bytes: &[u8]) -> IResult<&[u8], RSAPublicKey<'_>, X509Error> {
     let input = Input::from(bytes);
     let (rem, (o1, o2)) = <(Integer, Integer)>::parse_der(input).map_err(Err::convert)?;
     let modulus = o1

--- a/src/revocation_list.rs
+++ b/src/revocation_list.rs
@@ -66,7 +66,7 @@ impl<'a> CertificateRevocationList<'a> {
 
     /// Get the certificate issuer.
     #[inline]
-    pub fn issuer(&self) -> &X509Name {
+    pub fn issuer(&self) -> &X509Name<'_> {
         &self.tbs_cert_list.issuer
     }
 
@@ -89,7 +89,7 @@ impl<'a> CertificateRevocationList<'a> {
 
     /// Get the CRL extensions.
     #[inline]
-    pub fn extensions(&self) -> &[X509Extension] {
+    pub fn extensions(&self) -> &[X509Extension<'_>] {
         &self.tbs_cert_list.extensions
     }
 
@@ -179,27 +179,27 @@ pub struct TbsCertList<'a> {
 impl TbsCertList<'_> {
     /// Returns the certificate extensions
     #[inline]
-    pub fn extensions(&self) -> &[X509Extension] {
+    pub fn extensions(&self) -> &[X509Extension<'_>] {
         &self.extensions
     }
 
     /// Returns an iterator over the certificate extensions
     #[inline]
-    pub fn iter_extensions(&self) -> impl Iterator<Item = &X509Extension> {
+    pub fn iter_extensions(&self) -> impl Iterator<Item = &X509Extension<'_>> {
         self.extensions.iter()
     }
 
     /// Searches for an extension with the given `Oid`.
     ///
     /// Note: if there are several extensions with the same `Oid`, the first one is returned.
-    pub fn find_extension(&self, oid: &Oid) -> Option<&X509Extension> {
+    pub fn find_extension(&self, oid: &Oid) -> Option<&X509Extension<'_>> {
         self.extensions.iter().find(|&ext| ext.oid == *oid)
     }
 
     /// Builds and returns a map of extensions.
     ///
     /// If an extension is present twice, this will fail and return `DuplicateExtensions`.
-    pub fn extensions_map(&self) -> Result<HashMap<Oid, &X509Extension>, X509Error> {
+    pub fn extensions_map(&self) -> Result<HashMap<Oid<'_>, &X509Extension<'_>>, X509Error> {
         self.extensions
             .iter()
             .try_fold(HashMap::new(), |mut m, ext| {
@@ -297,27 +297,27 @@ impl RevokedCertificate<'_> {
 
     /// Get the CRL entry extensions.
     #[inline]
-    pub fn extensions(&self) -> &[X509Extension] {
+    pub fn extensions(&self) -> &[X509Extension<'_>] {
         &self.extensions
     }
 
     /// Returns an iterator over the CRL entry extensions
     #[inline]
-    pub fn iter_extensions(&self) -> impl Iterator<Item = &X509Extension> {
+    pub fn iter_extensions(&self) -> impl Iterator<Item = &X509Extension<'_>> {
         self.extensions.iter()
     }
 
     /// Searches for a CRL entry extension with the given `Oid`.
     ///
     /// Note: if there are several extensions with the same `Oid`, the first one is returned.
-    pub fn find_extension(&self, oid: &Oid) -> Option<&X509Extension> {
+    pub fn find_extension(&self, oid: &Oid) -> Option<&X509Extension<'_>> {
         self.extensions.iter().find(|&ext| ext.oid == *oid)
     }
 
     /// Builds and returns a map of CRL entry extensions.
     ///
     /// If an extension is present twice, this will fail and return `DuplicateExtensions`.
-    pub fn extensions_map(&self) -> Result<HashMap<Oid, &X509Extension>, X509Error> {
+    pub fn extensions_map(&self) -> Result<HashMap<Oid<'_>, &X509Extension<'_>>, X509Error> {
         self.extensions
             .iter()
             .try_fold(HashMap::new(), |mut m, ext| {

--- a/src/signature_algorithm.rs
+++ b/src/signature_algorithm.rs
@@ -103,12 +103,12 @@ pub struct RsaSsaPssParams<'a> {
 
 impl<'a> RsaSsaPssParams<'a> {
     /// Get a reference to the rsa ssa pss params's hash algorithm.
-    pub fn hash_algorithm(&self) -> Option<&AlgorithmIdentifier> {
+    pub fn hash_algorithm(&self) -> Option<&AlgorithmIdentifier<'_>> {
         self.hash_alg.as_ref()
     }
 
     /// Return the hash algorithm OID, or SHA1 if absent (RFC4055)
-    pub fn hash_algorithm_oid(&self) -> &'a Oid {
+    pub fn hash_algorithm_oid(&self) -> &'a Oid<'_> {
         const SHA1: &Oid = &OID_HASH_SHA1;
         self.hash_alg
             .as_ref()
@@ -117,14 +117,14 @@ impl<'a> RsaSsaPssParams<'a> {
     }
 
     /// Get a reference to the rsa ssa pss params's mask generation algorithm.
-    pub fn mask_gen_algorithm_raw(&self) -> Option<&AlgorithmIdentifier> {
+    pub fn mask_gen_algorithm_raw(&self) -> Option<&AlgorithmIdentifier<'_>> {
         self.mask_gen_algorithm.as_ref()
     }
 
     /// Get the rsa ssa pss params's mask generation algorithm.
     ///
     /// If the algorithm encoding is invalid, raise an error `InvalidAlgorithmIdentifier`
-    pub fn mask_gen_algorithm(&self) -> Result<MaskGenAlgorithm, X509Error> {
+    pub fn mask_gen_algorithm(&self) -> Result<MaskGenAlgorithm<'_, '_>, X509Error> {
         match self.mask_gen_algorithm.as_ref() {
             Some(alg) => {
                 let (_, hash) = alg
@@ -209,12 +209,12 @@ impl<'a> RsaAesOaepParams<'a> {
     );
 
     /// Get a reference to the rsa aes oaep params's hash algorithm.
-    pub fn hash_algorithm(&self) -> Option<&AlgorithmIdentifier> {
+    pub fn hash_algorithm(&self) -> Option<&AlgorithmIdentifier<'_>> {
         self.hash_alg.as_ref()
     }
 
     /// Return the hash algorithm OID, or SHA1 if absent (RFC4055)
-    pub fn hash_algorithm_oid(&self) -> &'a Oid {
+    pub fn hash_algorithm_oid(&self) -> &'a Oid<'_> {
         const SHA1: &Oid = &OID_HASH_SHA1;
         self.hash_alg
             .as_ref()
@@ -223,14 +223,14 @@ impl<'a> RsaAesOaepParams<'a> {
     }
 
     /// Get a reference to the rsa ssa pss params's mask generation algorithm.
-    pub fn mask_gen_algorithm_raw(&self) -> Option<&AlgorithmIdentifier> {
+    pub fn mask_gen_algorithm_raw(&self) -> Option<&AlgorithmIdentifier<'_>> {
         self.mask_gen_alg.as_ref()
     }
 
     /// Get the rsa ssa pss params's mask generation algorithm.
     ///
     /// If the algorithm encoding is invalid, raise an error `InvalidAlgorithmIdentifier`
-    pub fn mask_gen_algorithm(&self) -> Result<MaskGenAlgorithm, X509Error> {
+    pub fn mask_gen_algorithm(&self) -> Result<MaskGenAlgorithm<'_, '_>, X509Error> {
         match self.mask_gen_alg.as_ref() {
             Some(alg) => {
                 let hash = alg

--- a/src/x509.rs
+++ b/src/x509.rs
@@ -247,7 +247,7 @@ pub struct SubjectPublicKeyInfo<'a> {
 
 impl SubjectPublicKeyInfo<'_> {
     /// Attempt to parse the public key, and return the parsed version or an error
-    pub fn parsed(&self) -> Result<PublicKey, X509Error> {
+    pub fn parsed(&self) -> Result<PublicKey<'_>, X509Error> {
         let b = self.subject_public_key.as_raw_slice();
         if self.algorithm.algorithm == OID_PKCS1_RSAENCRYPTION {
             let (_, key) = RSAPublicKey::from_der(b).map_err(|_| X509Error::InvalidSPKI)?;

--- a/tests/readcsr.rs
+++ b/tests/readcsr.rs
@@ -155,7 +155,7 @@ fn read_csr_with_custom_extension() {
                 assert_eq!(req.extensions.len(), 1);
                 let extension = req.extensions.first().unwrap();
                 assert_eq!(extension.oid, OID_CUSTOM_EXTENSION);
-                assert_eq!(extension.critical, false);
+                assert!(!extension.critical);
                 assert_eq!(extension.value.as_bytes2(), VALUE_CUSTOM_EXTENSION);
             }
             _ => unreachable!(),
@@ -167,7 +167,7 @@ fn read_csr_with_custom_extension() {
         if let ParsedExtension::UnsupportedExtension(ext) = extension {
             assert_eq!(ext.oid, OID_CUSTOM_EXTENSION);
             assert_eq!(ext.value, VALUE_CUSTOM_EXTENSION);
-            assert_eq!(ext.critical, false);
+            assert!(!ext.critical);
         }
     }
 }


### PR DESCRIPTION
Replaces #211 
Changes:
- split commits for each warning type
- use anonymous lifetimes in `src/lib.rs`