### PR TITLE
Dev 0.18/add raw bytes full struct v0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,9 +111,9 @@ checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "cc"
-version = "1.2.31"
+version = "1.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3a42d84bb6b69d3a8b3eaacf0d88f179e1929695e1ad012b6cf64d9caaa5fd2"
+checksum = "2352e5597e9c544d5e6d9c95190d5d27738ade584fa8db0a16e130e5c2b5296e"
 dependencies = [
  "jobserver",
  "libc",
@@ -248,9 +248,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "home"
@@ -300,9 +300,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libloading"
@@ -415,9 +415,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "d61789d7719defeb74ea5fe81f2fdfdbd28a803847077cecce2ff14e1472f6f1"
 dependencies = [
  "unicode-ident",
 ]
@@ -536,9 +536,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "7bc3fcb250e53458e712715cf74285c1f889686520d79294a9ef3bd7aa1fc619"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -558,18 +558,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "0b0949c3a6c842cbde3f1686d6eea5a010516deb7085f79db747562d4102f41e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "cc5b44b4ab9c2fdd0e0512e6bece8388e214c0749f5862b114cc5b7a25daf227"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/certificate.rs
+++ b/src/certificate.rs
@@ -67,12 +67,17 @@ pub struct X509Certificate<'a> {
     pub signature_algorithm: AlgorithmIdentifier<'a>,
     pub signature_value: BitString<'a>,
 
+    /// Complete raw ASN.1 DER content (TBS certificate, signature algorithm and signature).
     pub(crate) raw: &'a [u8],
 }
 
 impl<'a> X509Certificate<'a> {
-    /// Return a reference to the raw bytes used to parse the certificate
-    // Not using the AsRef trait, as that would not give back the full 'a lifetime
+    /// Return the raw ASN.1 DER content of the complete signed certificate that was parsed.
+    ///
+    /// This includes the to-be-signed (TBS) certificate, the signature algorithm, and the signature.
+    /// If you want just the ASN.1 DER of the TBS certificate, prefer [`TbsCertificate::as_ref()`].
+    ///
+    /// We avoid the `AsRef` trait in this instance to ensure the full lifetime of the `X509Certificate` is used.
     pub fn as_raw(&self) -> &'a [u8] {
         self.raw
     }

--- a/src/certificate.rs
+++ b/src/certificate.rs
@@ -103,6 +103,12 @@ impl<'a> X509Certificate<'a> {
     }
 }
 
+impl<'a> AsRef<[u8]> for X509Certificate<'a> {
+    fn as_ref(&self) -> &[u8] {
+        self.as_raw()
+    }
+}
+
 impl<'a> Deref for X509Certificate<'a> {
     type Target = TbsCertificate<'a>;
 

--- a/src/certification_request.rs
+++ b/src/certification_request.rs
@@ -20,12 +20,16 @@ pub struct X509CertificationRequest<'a> {
     pub signature_algorithm: AlgorithmIdentifier<'a>,
     pub signature_value: BitString<'a>,
 
+    /// Complete raw ASN.1 DER content (request info, signature algorithm and signature).
     pub(crate) raw: &'a [u8],
 }
 
 impl<'a> X509CertificationRequest<'a> {
-    /// Return a reference to the raw bytes used to parse the Certificate Request
-    // Not using the AsRef trait, as that would not give back the full 'a lifetime
+    /// Return the raw ASN.1 DER content of the complete signed certification request that was parsed.
+    ///
+    /// This includes the certification request info, the signature algorithm, and the signature.
+    ///
+    /// We avoid the `AsRef` trait in this instance to ensure the full lifetime of the `X509CertificationRequest` is used.
     pub fn as_raw(&self) -> &'a [u8] {
         self.raw
     }

--- a/src/certification_request.rs
+++ b/src/certification_request.rs
@@ -58,6 +58,12 @@ impl<'a> X509CertificationRequest<'a> {
     }
 }
 
+impl<'a> AsRef<[u8]> for X509CertificationRequest<'a> {
+    fn as_ref(&self) -> &[u8] {
+        self.as_raw()
+    }
+}
+
 /// <pre>
 /// CertificationRequest ::= SEQUENCE {
 ///     certificationRequestInfo CertificationRequestInfo,

--- a/src/revocation_list.rs
+++ b/src/revocation_list.rs
@@ -131,6 +131,12 @@ impl<'a> CertificateRevocationList<'a> {
     }
 }
 
+impl<'a> AsRef<[u8]> for CertificateRevocationList<'a> {
+    fn as_ref(&self) -> &[u8] {
+        self.as_raw()
+    }
+}
+
 /// <pre>
 /// CertificateList  ::=  SEQUENCE  {
 ///      tbsCertList          TBSCertList,

--- a/src/revocation_list.rs
+++ b/src/revocation_list.rs
@@ -52,6 +52,7 @@ pub struct CertificateRevocationList<'a> {
     pub signature_algorithm: AlgorithmIdentifier<'a>,
     pub signature_value: BitString<'a>,
 
+    /// Complete raw ASN.1 DER content (TBS certificate list, signature algorithm and signature).
     pub(crate) raw: &'a [u8],
 }
 
@@ -123,9 +124,14 @@ impl<'a> CertificateRevocationList<'a> {
             self.tbs_cert_list.raw,
         )
     }
+
     ///
-    /// Return a reference to the raw bytes used to parse the Certificate Revocation List
-    // Not using the AsRef trait, as that would not give back the full 'a lifetime
+    /// Return the raw ASN.1 DER content of the complete signed certificate revocation list that was parsed.
+    ///
+    /// This includes the to-be-signed (TBS) certificate list, the signature algorithm, and the signature.
+    /// If you want just the ASN.1 DER of the TBS certificate list, prefer [`TbsCertList::as_ref()`].
+    ///
+    /// We avoid the `AsRef` trait in this instance to ensure the full lifetime of the `CertificateRevocationList` is used.
     pub fn as_raw(&self) -> &'a [u8] {
         self.raw
     }

--- a/tests/readcert.rs
+++ b/tests/readcert.rs
@@ -123,6 +123,8 @@ fn test_x509_parser() {
             assert!(tbs_cert.is_ca());
             //
             assert_eq!(tbs_cert.as_ref(), &IGCA_DER[4..(8 + 746)]);
+            // check that cert.as_raw() returns the certificate bytes
+            assert_eq!(cert.as_raw(), IGCA_DER);
         }
         _ => panic!("x509 parsing failed: {:?}", res),
     }

--- a/tests/readcrl.rs
+++ b/tests/readcrl.rs
@@ -11,6 +11,9 @@ fn read_crl_verify() {
     let res = crl.verify_signature(&x509_ca.tbs_certificate.subject_pki);
     eprintln!("Verification: {res:?}");
     assert!(res.is_ok());
+
+    // check that `.as_raw()` returns the input bytes
+    assert_eq!(crl.as_raw(), CRL_DATA);
 }
 
 fn crl_idp<'a>(crl: &'a CertificateRevocationList) -> &'a IssuingDistributionPoint<'a> {

--- a/tests/readcsr.rs
+++ b/tests/readcsr.rs
@@ -109,8 +109,8 @@ fn read_csr_with_challenge_password() {
 #[cfg(feature = "verify")]
 #[test]
 fn read_csr_verify() {
-    let der = pem::parse_x509_pem(CSR_DATA).unwrap().1;
-    let (_, csr) = X509CertificationRequest::from_der(&der.contents).expect("could not parse CSR");
+    let pem = pem::parse_x509_pem(CSR_DATA).unwrap().1;
+    let (_, csr) = X509CertificationRequest::from_der(&pem.contents).expect("could not parse CSR");
     csr.verify_signature().unwrap();
 
     let mut der = pem::parse_x509_pem(CSR_DATA).unwrap().1;
@@ -122,4 +122,7 @@ fn read_csr_verify() {
 
     let (_, csr) = X509CertificationRequest::from_der(&der.contents).expect("could not parse CSR");
     csr.verify_signature().unwrap_err();
+
+    // check that `.as_raw()` returns the input bytes
+    assert_eq!(csr.as_raw(), &der.contents);
 }


### PR DESCRIPTION
*target branch is 0.18*

Add `as_raw` method to top-level structs (`X509Certificate`, `CertificateRevocationList` and `X509CertificationRequest`) to expose bytes that were used during parsing.

closes #217 