### PR TITLE
fix(verify): also enable all functions when using verify-aws

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,14 +83,14 @@ See also `examples/print-cert.rs`.
 
 # Features
 
-- The `verify` feature adds support for (cryptographic) signature verification, based on `ring`.
+- The `verify` and `verify-aws` features adds support for (cryptographic) signature verification, based on `ring` or `aws-lc` respectively.
   It adds the
   [`X509Certificate::verify_signature()`](https://docs.rs/x509-parser/latest/x509_parser/certificate/struct.X509Certificate.html#method.verify_signature)
   to `X509Certificate`.
 
 ```rust
 /// Cryptographic signature verification: returns true if certificate was signed by issuer
-#[cfg(feature = "verify")]
+#[cfg(any(feature = "verify", feature = "verify-aws"))]
 pub fn check_signature(cert: &X509Certificate<'_>, issuer: &X509Certificate<'_>) -> bool {
     let issuer_public_key = issuer.public_key();
     cert

--- a/examples/print-cert.rs
+++ b/examples/print-cert.rs
@@ -208,7 +208,7 @@ fn print_x509_info(x509: &X509Certificate) -> io::Result<()> {
     {
         println!("Unknown (feature 'validate' not enabled)");
     }
-    #[cfg(feature = "verify")]
+    #[cfg(any(feature = "verify", feature = "verify-aws"))]
     {
         print!("Signature verification: ");
         if x509.subject() == x509.issuer() {

--- a/src/certificate.rs
+++ b/src/certificate.rs
@@ -11,7 +11,7 @@ use crate::x509::{
     X509Version,
 };
 
-#[cfg(feature = "verify")]
+#[cfg(any(feature = "verify", feature = "verify-aws"))]
 use crate::verify::verify_signature;
 use asn1_rs::{BitString, FromDer, OptTaggedImplicit};
 use core::ops::Deref;
@@ -92,8 +92,8 @@ impl<'a> X509Certificate<'a> {
     /// It is usually an intermediate authority.
     ///
     /// Not all algorithms are supported, this function is limited to what `ring` supports.
-    #[cfg(feature = "verify")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "verify")))]
+    #[cfg(any(feature = "verify", feature = "verify-aws"))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "verify", feature = "verify-aws"))))]
     pub fn verify_signature(
         &self,
         public_key: Option<&SubjectPublicKeyInfo>,

--- a/src/certification_request.rs
+++ b/src/certification_request.rs
@@ -5,7 +5,7 @@ use crate::x509::{
     parse_signature_value, AlgorithmIdentifier, SubjectPublicKeyInfo, X509Name, X509Version,
 };
 
-#[cfg(feature = "verify")]
+#[cfg(any(feature = "verify", feature = "verify-aws"))]
 use crate::verify::verify_signature;
 use asn1_rs::{BitString, FromDer};
 use der_parser::der::*;
@@ -50,7 +50,8 @@ impl<'a> X509CertificationRequest<'a> {
     ///
     /// Uses the public key contained in the CSR, which must be the one of the entity
     /// requesting the certification for this verification to succeed.
-    #[cfg(feature = "verify")]
+    #[cfg(any(feature = "verify", feature = "verify-aws"))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "verify", feature = "verify-aws"))))]
     pub fn verify_signature(&self) -> Result<(), X509Error> {
         let spki = &self.certification_request_info.subject_pki;
         verify_signature(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,16 +87,16 @@
 //!
 //! # Features
 //!
-//! - The `verify` feature adds support for (cryptographic) signature verification, based on `ring`.
+//! - The `verify` and `verify-aws` features adds support for (cryptographic) signature verification, based on `ring` or `aws-lc` respectively.
 //!   It adds the
 //!   [`X509Certificate::verify_signature()`](certificate/struct.X509Certificate.html#method.verify_signature)
 //!   to `X509Certificate`.
 //!
 //! ```rust
-//! # #[cfg(feature = "verify")]
+//! # #[cfg(any(feature = "verify", feature = "verify-aws"))]
 //! # use x509_parser::certificate::X509Certificate;
 //! /// Cryptographic signature verification: returns true if certificate was signed by issuer
-//! #[cfg(feature = "verify")]
+//! #[cfg(any(feature = "verify", feature = "verify-aws"))]
 //! pub fn check_signature(cert: &X509Certificate<'_>, issuer: &X509Certificate<'_>) -> bool {
 //!     let issuer_public_key = issuer.public_key();
 //!     cert

--- a/src/revocation_list.rs
+++ b/src/revocation_list.rs
@@ -6,9 +6,9 @@ use crate::x509::{
     parse_serial, parse_signature_value, AlgorithmIdentifier, ReasonCode, X509Name, X509Version,
 };
 
-#[cfg(feature = "verify")]
+#[cfg(any(feature = "verify", feature = "verify-aws"))]
 use crate::verify::verify_signature;
-#[cfg(feature = "verify")]
+#[cfg(any(feature = "verify", feature = "verify-aws"))]
 use crate::x509::SubjectPublicKeyInfo;
 use asn1_rs::{BitString, FromDer};
 use der_parser::der::*;
@@ -114,8 +114,8 @@ impl<'a> CertificateRevocationList<'a> {
     /// `public_key` is the public key of the **signer**.
     ///
     /// Not all algorithms are supported, this function is limited to what `ring` supports.
-    #[cfg(feature = "verify")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "verify")))]
+    #[cfg(any(feature = "verify", feature = "verify-aws"))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "verify", feature = "verify-aws"))))]
     pub fn verify_signature(&self, public_key: &SubjectPublicKeyInfo) -> Result<(), X509Error> {
         verify_signature(
             public_key,

--- a/tests/readcrl.rs
+++ b/tests/readcrl.rs
@@ -1,6 +1,6 @@
 use x509_parser::prelude::*;
 
-#[cfg(feature = "verify")]
+#[cfg(any(feature = "verify", feature = "verify-aws"))]
 #[test]
 fn read_crl_verify() {
     const CA_DATA: &[u8] = include_bytes!("../assets/ca_minimalcrl.der");

--- a/tests/readcsr.rs
+++ b/tests/readcsr.rs
@@ -106,7 +106,7 @@ fn read_csr_with_challenge_password() {
     assert!(found_san);
 }
 
-#[cfg(feature = "verify")]
+#[cfg(any(feature = "verify", feature = "verify-aws"))]
 #[test]
 fn read_csr_verify() {
     let pem = pem::parse_x509_pem(CSR_DATA).unwrap().1;

--- a/tests/verify.rs
+++ b/tests/verify.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "verify")]
+#![cfg(any(feature = "verify", feature = "verify-aws"))]
 
 use x509_parser::parse_x509_certificate;
 


### PR DESCRIPTION
Backport fix for feature `verify-aws` (see #220) for branch 0.18
