### PR TITLE
Prepare 0.18.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -825,7 +825,7 @@ dependencies = [
 
 [[package]]
 name = "x509-parser"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "asn1-rs",
  "aws-lc-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x509-parser"
-version = "0.18.0"
+version = "0.18.1"
 description = "Parser for the X.509 v3 format (RFC 5280 certificates)"
 license = "MIT OR Apache-2.0"
 keywords = ["X509","Certificate","parser","nom"]

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ See also `examples/print-cert.rs`.
 
 # Features
 
-- The `verify` and `verify-aws` features adds support for (cryptographic) signature verification, based on `ring` or `aws-lc` respectively.
+- The `verify` and `verify-aws` features add support for (cryptographic) signature verification, based on `ring` or `aws-lc` respectively.
   It adds the
   [`X509Certificate::verify_signature()`](https://docs.rs/x509-parser/latest/x509_parser/certificate/struct.X509Certificate.html#method.verify_signature)
   to `X509Certificate`.
@@ -99,7 +99,7 @@ pub fn check_signature(cert: &X509Certificate<'_>, issuer: &X509Certificate<'_>)
 }
 ```
 
-- The `validate` features add methods to run more validation functions on the certificate structure
+- The `validate` feature add methods to run more validation functions on the certificate structure
   and values using the [`Validate`](https://docs.rs/x509-parser/latest/x509_parser/validate/trait.Validate.html) trait.
   It does not validate any cryptographic parameter (see `verify` above).
 


### PR DESCRIPTION
https://github.com/rusticata/x509-parser/pull/220 was backported to the `x509-parser-0.18` branch but not released. This branch increments the version to prepare a 0.18.1 release.

See https://github.com/rustls/rcgen/issues/400
