### PR TITLE
feat: add wasm-bindgen feature for wasm

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,6 +4,7 @@ on:
   push:
   pull_request:
   merge_group:
+  workflow_dispatch:
   schedule:
     - cron: '0 18 * * *'
 
@@ -118,3 +119,16 @@ jobs:
         uses: actions/checkout@v4
       - name: Check semver
         uses: obi1kenobi/cargo-semver-checks-action@v2
+
+  wasm-test:
+    name: Wasm test Suite
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: rustup target add wasm32-unknown-unknown
+      # TODO: If the MSRV is updated, we can remove this step and just add the dev-dependency to Cargo.toml
+      - run: cargo add wasm-bindgen-test --dev # ensure dependency is present for wasm tests
+      - run: cargo install wasm-pack --locked
+      - run: wasm-pack test --node

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,6 +125,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+
+[[package]]
 name = "cc"
 version = "1.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -297,6 +303,16 @@ checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
 dependencies = [
  "getrandom 0.3.3",
  "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.85"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -537,6 +553,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "serde"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -618,6 +640,7 @@ checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
  "itoa",
+ "js-sys",
  "num-conv",
  "powerfmt",
  "serde",
@@ -672,6 +695,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.108"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,9 @@ rusticata-macros = "5.0"
 thiserror = "2.0"
 time = { version="0.3.35", features=["formatting"] }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+time = { version="0.3.35", features=["formatting", "wasm-bindgen"] }
+
 [dev-dependencies]
 hex-literal = "0.4"
 

--- a/src/public_key.rs
+++ b/src/public_key.rs
@@ -60,7 +60,7 @@ impl RSAPublicKey<'_> {
     /// Return the key size (in bits) or 0
     pub fn key_size(&self) -> usize {
         if !self.modulus.is_empty() && self.modulus[0] & 0x80 == 0 {
-            // XXX len must substract leading zeroes
+            // XXX len must subtract leading zeroes
             let modulus = &self.modulus[1..];
             8 * modulus.len()
         } else {

--- a/src/validate/mod.rs
+++ b/src/validate/mod.rs
@@ -84,7 +84,7 @@ pub trait Validate {
     /// Returns `true` if item was validated.
     ///
     /// Call `warn()` if a non-fatal error was encountered, and `err()`
-    /// if the error is fatal. These fucntions receive a description of the error.
+    /// if the error is fatal. These functions receive a description of the error.
     fn validate<W, E>(&self, warn: W, err: E) -> bool
     where
         W: FnMut(&str),

--- a/tests/test01.rs
+++ b/tests/test01.rs
@@ -1,17 +1,21 @@
-use nom::bytes::complete::take;
-
 #[test]
 fn test01() {
     let data = b"0\x88\xff\xff\xff\xff\xff\xff\xff\xff00\x0f\x02\x000\x00\x00\x00\x00\x00\x0000\x0f\x00\xff\x0a\xbb\xff";
     let _ = x509_parser::parse_x509_certificate(data);
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn parser02(input: &[u8]) -> nom::IResult<&[u8], ()> {
+    use nom::bytes::complete::take;
     let (_hdr, input) = take(1_usize)(input)?;
     let (_data, input) = take(18_446_744_073_709_551_615_usize)(input)?;
     Ok((input, ()))
 }
 
+/// This test is not running on wasm32 because `parser02` needs a big usize
+/// Therefore on wasm32 target it triggers a compilation error:
+/// literal out of range for `usize``
+#[cfg(not(target_arch = "wasm32"))]
 #[test]
 fn test02() {
     let data = b"0\x88\xff\xff\xff\xff\xff\xff\xff\xff00\x0f\x02\x000\x00\x00\x00\x00\x00\x0000\x0f\x00\xff\x0a\xbb\xff";

--- a/tests/wasm32.rs
+++ b/tests/wasm32.rs
@@ -1,0 +1,26 @@
+//! This file is used to test the time crate with wasm.
+//! This needs the `wasm-bindgen-test` crate to compile
+//!
+//! ```sh
+//! # cargo add wasm-bindgen-test --dev
+//! wasm-pack test --node
+//! ```
+//!
+
+#![cfg(target_arch = "wasm32")]
+
+use x509_parser::pem::Pem;
+
+static IGCA_PEM: &[u8] = include_bytes!("../assets/IGC_A.pem");
+
+/// This test is used to check if the time crate is working correctly on wasm32 target
+/// because it is used in the x509 parser to check the validity of the certificate
+#[wasm_bindgen_test::wasm_bindgen_test]
+fn test_x509_parse_pem() {
+    let pem: Vec<Pem> = Pem::iter_from_buffer(IGCA_PEM)
+        .collect::<Result<_, _>>()
+        .ok()
+        .unwrap();
+    let x509 = pem[0].parse_x509().unwrap();
+    assert_eq!(x509.validity.is_valid(), false);
+}


### PR DESCRIPTION
This MR add the wasm-bindgen feature of the `time` crate on wasm https://docs.rs/crate/time/latest/features 

Without the feature we have the error

```
time not implemented on this platform
```

Test file

```rust
//! cargo add --dev wasm-bindgen-test
//! wasm-pack test --node
#![cfg(target_arch = "wasm32")]

use x509_parser::pem::{parse_x509_pem, Pem};
use x509_parser::{parse_x509_certificate, x509::X509Version};

static IGCA_PEM: &[u8] = include_bytes!("../assets/IGC_A.pem");



#[wasm_bindgen_test::wasm_bindgen_test]
fn test_x509_parse_pem() {
    let pem: Vec<Pem> = Pem::iter_from_buffer(IGCA_PEM)
        .collect::<Result<_, _>>()
        .ok()
        .unwrap();
    let x509 = pem[0].parse_x509().unwrap();
    assert_eq!(x509.validity.is_valid(), false);
}
```

```sh
cargo install wasm-pack

cargo add --dev wasm-bindgen-test
wasm-pack test --node
```