### PR TITLE
fix: remove dead code, fix ns_comment remainder, and correct doc comments

### DIFF
--- a/src/certification_request.rs
+++ b/src/certification_request.rs
@@ -192,26 +192,26 @@ pub struct X509CertificationRequestInfo<'a> {
 }
 
 impl X509CertificationRequestInfo<'_> {
-    /// Get the CRL entry extensions.
+    /// Get the CSR attributes.
     #[inline]
     pub fn attributes(&self) -> &[X509CriAttribute<'_>] {
         &self.attributes
     }
 
-    /// Returns an iterator over the CRL entry extensions
+    /// Returns an iterator over the CSR attributes
     #[inline]
     pub fn iter_attributes(&self) -> impl Iterator<Item = &X509CriAttribute<'_>> {
         self.attributes.iter()
     }
 
-    /// Searches for a CRL entry extension with the given `Oid`.
+    /// Searches for a CSR attribute with the given `Oid`.
     ///
     /// Note: if there are several extensions with the same `Oid`, the first one is returned.
     pub fn find_attribute(&self, oid: &Oid) -> Option<&X509CriAttribute<'_>> {
         self.attributes.iter().find(|&ext| ext.oid == *oid)
     }
 
-    /// Builds and returns a map of CRL entry extensions.
+    /// Builds and returns a map of CSR attributes.
     ///
     /// If an extension is present twice, this will fail and return `DuplicateExtensions`.
     pub fn attributes_map(&self) -> Result<HashMap<Oid<'_>, &X509CriAttribute<'_>>, X509Error> {

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -9,7 +9,7 @@ use asn1_rs::{
 };
 use nom::combinator::{all_consuming, complete, map};
 use nom::multi::many0;
-use nom::{Err, IResult, Input as _, Mode, Parser};
+use nom::{Err, IResult, Mode, Parser};
 use oid_registry::*;
 use std::collections::HashMap;
 
@@ -229,7 +229,6 @@ impl<'i> Parser<Input<'i>> for X509ExtensionParser {
             let parsed_extension = if self.deep_parse_extensions {
                 parser::parse_extension(value.clone(), &oid, critical)
             } else {
-                rem.take(rem.input_len());
                 ParsedExtension::Unparsed
             };
 

--- a/src/extensions/ns_comment.rs
+++ b/src/extensions/ns_comment.rs
@@ -17,7 +17,7 @@ pub fn parse_der_nscomment(input: Input<'_>) -> IResult<Input<'_>, &str, X509Err
             // Some implementations encode the comment directly, without
             // wrapping it in an IA5String
             if let Ok(s) = std::str::from_utf8(input.as_bytes2()) {
-                Ok((input.take(input.input_len()), s))
+                Ok((input.take_from(input.input_len()), s))
             } else {
                 Err(Err::Error(X509Error::DerParser(
                     InnerError::StringInvalidCharset,


### PR DESCRIPTION
## Summary
Three small fixes:

1. **Dead code in extension parser** (`extensions/mod.rs`): Removed `rem.take(rem.input_len())` which had no effect — `take` returns a new value without mutating `rem`, so the result was silently discarded

2. **Incorrect remainder in ns_comment fallback** (`extensions/ns_comment.rs`): The fallback parser for non-IA5String-wrapped comments used `input.take(input.input_len())` as the remainder, which returns the full input instead of an empty slice. Fixed to use `input.take_from(input.input_len())` consistent with the pattern used in `generalname.rs`

3. **Wrong doc comments** (`certification_request.rs`): Four doc comments on `X509CertificationRequestInfo` methods incorrectly referred to "CRL entry extensions" instead of "CSR attributes"

## Test plan
- [x] Full test suite passes with `cargo test --all-features`