### PR TITLE
Reject CONTEXT-SPECIFIC tag class in serial number parser

### DIFF
--- a/src/validate/extensions.rs
+++ b/src/validate/extensions.rs
@@ -97,11 +97,10 @@ impl<'a> Validator<'a> for X509ExtensionsValidator {
                     test_critical!(SHOULD NOT ext, l, "SubjectAltName");
                     for name in san.general_names() {
                         match name {
-                            GeneralName::DNSName(ref s) | GeneralName::RFC822Name(ref s) => {
-                                // should be an ia5string
-                                if !s.as_bytes().iter().all(u8::is_ascii) {
-                                    l.warn(&format!("Invalid charset in 'SAN' entry '{s}'"));
-                                }
+                            GeneralName::DNSName(ref s) | GeneralName::RFC822Name(ref s)
+                                if !s.as_bytes().iter().all(u8::is_ascii) =>
+                            {
+                                l.warn(&format!("Invalid charset in 'SAN' entry '{s}'"));
                             }
                             _ => (),
                         }

--- a/src/validate/structure.rs
+++ b/src/validate/structure.rs
@@ -140,11 +140,10 @@ impl<'a> Validator<'a> for TbsCertificateStructureValidator {
             if let ParsedExtension::SubjectAlternativeName(san) = ext.parsed_extension() {
                 for name in san.general_names() {
                     match name {
-                        GeneralName::DNSName(ref s) | GeneralName::RFC822Name(ref s) => {
-                            // should be an ia5string
-                            if !s.as_bytes().iter().all(u8::is_ascii) {
-                                l.warn(&format!("Invalid charset in 'SAN' entry '{s}'"));
-                            }
+                        GeneralName::DNSName(ref s) | GeneralName::RFC822Name(ref s)
+                            if !s.as_bytes().iter().all(u8::is_ascii) =>
+                        {
+                            l.warn(&format!("Invalid charset in 'SAN' entry '{s}'"));
                         }
                         _ => (),
                     }

--- a/src/x509.rs
+++ b/src/x509.rs
@@ -766,6 +766,9 @@ mod tests {
         // X.690 §8.1.2: tag class must match the expected type
         let data: &[u8] = &[0x82, 0x01, 0x01]; // CONTEXT-SPECIFIC [2], length 1, value 1
         let r = parse_serial(Input::from(data));
-        assert!(r.is_err(), "should reject CONTEXT-SPECIFIC tag for serial number");
+        assert!(
+            r.is_err(),
+            "should reject CONTEXT-SPECIFIC tag for serial number"
+        );
     }
 }

--- a/src/x509.rs
+++ b/src/x509.rs
@@ -10,9 +10,9 @@ use crate::public_key::*;
 
 use asn1_rs::num_bigint::BigUint;
 use asn1_rs::{
-    Alias, Any, BerError, BitString, BmpString, Choice, DerParser, Enumerated, FromDer, Header,
-    Input, Integer, OptTaggedExplicit, PrintableString, Sequence, Tag, Tagged, TeletexString,
-    UniversalString, Utf8String,
+    Alias, Any, BerError, BitString, BmpString, Choice, Class, DerParser, Enumerated, FromDer,
+    Header, Input, Integer, OptTaggedExplicit, PrintableString, Sequence, Tag, Tagged,
+    TeletexString, UniversalString, Utf8String,
 };
 use core::convert::TryFrom;
 use data_encoding::HEXUPPER;
@@ -612,6 +612,10 @@ pub(crate) fn parse_serial(input: Input<'_>) -> IResult<Input<'_>, (&[u8], BigUi
     // RFC 5280 4.1.2.2: "The serial number MUST be a positive integer"
     // however, many CAs do not respect this and send integers with MSB set,
     // so we do not use `as_biguint()`
+    // X.690 §8.1.2: tag class must be UNIVERSAL for INTEGER
+    if any.class() != Class::Universal {
+        return Err(Err::Error(X509Error::InvalidSerial));
+    }
     any.tag()
         .assert_eq(Tag::Integer)
         .map_err(|_| X509Error::InvalidSerial)?;
@@ -754,5 +758,14 @@ mod tests {
         assert!(v.not_after.is_utctime());
         assert_eq!(v.not_before.to_datetime().year(), 2019);
         assert_eq!(v.not_after.to_datetime().year(), 2029);
+    }
+
+    #[test]
+    fn test_serial_rejects_context_specific_tag() {
+        // Tag byte 0x02 (UNIVERSAL INTEGER) → 0x82 (CONTEXT-SPECIFIC [2])
+        // X.690 §8.1.2: tag class must match the expected type
+        let data: &[u8] = &[0x82, 0x01, 0x01]; // CONTEXT-SPECIFIC [2], length 1, value 1
+        let r = parse_serial(Input::from(data));
+        assert!(r.is_err(), "should reject CONTEXT-SPECIFIC tag for serial number");
     }
 }


### PR DESCRIPTION
## Problem

`parse_serial()` checks that the tag number equals `Tag::Integer` but does not verify the tag class. A CONTEXT-SPECIFIC `[2]` tag byte (`0x82`) has the same tag number as UNIVERSAL INTEGER (`0x02`) but a different class per X.690 §8.1.2. This makes the parser accept certificates with mismatched tag classes.

13 of 14 tested X.509 implementations reject this mutation. Only x509-parser and mbedTLS accept. See #248.

## Fix

Check `any.class() == Class::Universal` before comparing the tag number.

```diff
     let (rem, any) = Any::parse_der(input).map_err(|_| X509Error::InvalidSerial)?;
+    if any.class() != Class::Universal {
+        return Err(Err::Error(X509Error::InvalidSerial));
+    }
     any.tag()
         .assert_eq(Tag::Integer)
```

## Test

Single-byte PoC: offset 0x0d of a standard RSA-2048 self-signed cert, tag byte changed from `0x02` to `0x82`.

Test added: `test_serial_rejects_context_specific_tag`. All 66 existing tests pass.