### PR TITLE
Fix typo in README.md (references #230)

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ pub fn check_signature(cert: &X509Certificate<'_>, issuer: &X509Certificate<'_>)
   `--all-features`), the verification will use `aws-lc-rs`. It also has the side-effect of
   having a dependency on `ring`, even if it is not used.
 
-- The `validate` feature add methods to run more validation functions on the certificate structure
+- The `validate` feature adds methods to run more validation functions on the certificate structure
   and values using the [`Validate`](https://docs.rs/x509-parser/latest/x509_parser/validate/trait.Validate.html) trait.
   It does not validate any cryptographic parameter (see `verify` above).
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,7 @@
 //!   `--all-features`), the verification will use `aws-lc-rs`. It also has the side-effect of
 //!   having a dependency on `ring`, even if it is not used.
 //!
-//! - The `validate` feature add methods to run more validation functions on the certificate structure
+//! - The `validate` feature adds methods to run more validation functions on the certificate structure
 //!   and values using the [`Validate`](crate::validate::Validate) trait.
 //!   It does not validate any cryptographic parameter (see `verify` above).
 //!


### PR DESCRIPTION
Followup from #230 for changes not merged in #223

Using gui to edit file in #230 was not a good idea.
Anyway, `README.md` changes go through `src/lib.rs`, so re-creating the patch