### PR TITLE
Fix clippy warning (simplify map_or -> is_some_and)

### DIFF
--- a/src/certificate.rs
+++ b/src/certificate.rs
@@ -597,7 +597,7 @@ impl<'a> TbsCertificate<'a> {
     /// `Ok(false)` if the extension is absent or `CA` is false,
     /// or an error if the extension could not be read (e.g. duplicate extensions).
     pub fn try_is_ca(&self) -> Result<bool, X509Error> {
-        Ok(self.basic_constraints()?.map_or(false, |ext| ext.value.ca))
+        Ok(self.basic_constraints()?.is_some_and(|ext| ext.value.ca))
     }
 
     /// Get the raw bytes of the certificate serial number


### PR DESCRIPTION
Fix clippy warning introduced when merging #237
```
error: this `map_or` can be simplified
   --> src/certificate.rs:600:12
    |
600 |         Ok(self.basic_constraints()?.map_or(false, |ext| ext.value.ca))
    |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#unnecessary_map_or
    = note: `-D clippy::unnecessary-map-or` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::unnecessary_map_or)]`
help: use `is_some_and` instead
    |
600 -         Ok(self.basic_constraints()?.map_or(false, |ext| ext.value.ca))
600 +         Ok(self.basic_constraints()?.is_some_and(|ext| ext.value.ca))
    |
```