### PR TITLE
CI: use rust 1.85 for MSRV version (missed update in last MSRV change)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.88
+          - 1.85
           - nightly
     steps:
       - uses: actions/checkout@v4
@@ -41,7 +41,7 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.88
+          - 1.85
           - nightly
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The rust version in CI was not updated correctly when switching back to 1.85